### PR TITLE
setup-node v1.x' usage of add-path is now disabled in GH

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         lfs: true
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: 12.x
 


### PR DESCRIPTION
setup-node v1.x' usage of add-path is now disabled in GH -> updating to v2-beta:

the setup-node@v1.x now fails all our workflows

2 options:
- either bypass the enforcement 
- or move to GH's setup-node@v2-beta; which is the latest available still :-(

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/