### PR TITLE
fix rolling CI build - missing solution to import

### DIFF
--- a/.github/workflows/rolling-instance-actions.yml
+++ b/.github/workflows/rolling-instance-actions.yml
@@ -16,6 +16,13 @@ jobs:
       with:
         lfs: true
 
+    - name: Test pack-solution action
+      uses: ./pack-solution
+      with:
+        solution-folder: 'src/test/data/emptySolution'
+        solution-file: 'out/CI/emptySolution.zip'
+        solution-type: 'Unmanaged'
+
     - name: Test import-solution action
       uses: ./import-solution
       with:

--- a/.github/workflows/rolling-instance-actions.yml
+++ b/.github/workflows/rolling-instance-actions.yml
@@ -2,6 +2,7 @@
 name: rolling-instance-actions
 
 on:
+  workflow_dispatch:    # allow for manual workflow triggering as needed
   push:
     branches: [ main ]
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "clean": "scorch",
-    "build": "gulp",
-    "test": "gulp test",
+    "build": "node node_modules/gulp/bin/gulp.js",
+    "test": "node node_modules/gulp/bin/gulp.js test",
     "ci": "node node_modules/gulp/bin/gulp.js ci",
-    "dist": "gulp recompile && gulp dist && git add -f -- ./dist"
+    "dist": "node node_modules/gulp/bin/gulp.js recompile && node node_modules/gulp/bin/gulp.js dist && git add -f -- ./dist"
   },
   "author": "PowerApps-ISV-Tools",
   "license": "MIT",


### PR DESCRIPTION
- add package solution for import to succeed
- opportunistic fix: do not assume gulp cli is on the path
- allow for manual triggering of CI workflow