### PR TITLE
PR Build improvements - Create test environment for the test run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,12 +34,23 @@ jobs:
       env:
         AZ_DevOps_Read_PAT: ${{ secrets.AZ_DevOps_Read_PAT }}
 
+    - name: Test create-environment action with username/password
+      uses: ./create-environment
+      id: create-environment
+      with:
+        user-name: ${{ env.WF_USERNAME }}
+        password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
+        name: pullRequestTestEnv
+        type: Sandbox
+        region: unitedstates
+        domain: test-target
+
     - name: Test who-am-i action
       uses: ./who-am-i
       with:
-        environment-url: 'https://davidjenD365-1.crm.dynamics.com'
-        user-name: 'davidjen@davidjenD365.onmicrosoft.com'
-        password-secret: ${{ secrets.password }}
+        environment-url: ${{ steps.create-environment.outputs.environment-url }}
+        user-name: ${{ env.WF_USERNAME }}
+        password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
 
     - name: Test pack-solution action
       if: matrix.os == 'windows-latest'
@@ -48,6 +59,13 @@ jobs:
         solution-folder: 'src/test/data/emptySolution'
         solution-file: 'out/CI/emptySolution.zip'
         solution-type: 'Unmanaged'
+
+    - name: Test delete-environment action with username/password
+      uses: ./delete-environment
+      with:
+        environment-url: ${{ steps.create-environment.outputs.environment-url }}
+        user-name: ${{ env.WF_USERNAME }}
+        password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
 
     - name: Upload test logs
       if: always()


### PR DESCRIPTION
The previous PR builds used a test environment that expires every 14 days.
By creating a new one for the PR run, we can avoid the need to recreate / reenable manually.