### PR TITLE
Delete test environments, even when test runs fail

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,6 +62,7 @@ jobs:
         solution-type: 'Unmanaged'
 
     - name: Test delete-environment action with username/password
+      if: always() # Clean up created environments even on failed run
       uses: ./delete-environment
       with:
         environment-url: ${{ steps.create-environment.outputs.environment-url }}

--- a/.github/workflows/rolling-instance-actions.yml
+++ b/.github/workflows/rolling-instance-actions.yml
@@ -146,6 +146,7 @@ jobs:
         password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
 
     - name: Test delete-source-environment action with appId-clientSecret
+      if: always() # Clean up created environments even on failed run
       uses: ./delete-environment
       with:
         environment-url: ${{ steps.create-source-environment.outputs.environment-url }}
@@ -153,6 +154,7 @@ jobs:
         password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
 
     - name: Test delete-target-environment action with username/password
+      if: always() # Clean up created environments even on failed run
       uses: ./delete-environment
       with:
         environment-url: ${{ steps.create-target-environment.outputs.environment-url }}


### PR DESCRIPTION
Previously, when a PR or Rolling Instance Actions run failed, the test environments created would still exist and clog up the test tenant.   This should grantee their deletion even on failure.