### PR TITLE
Guarantee that the linux pac executable has the execute flag set, even when modified on a Windows host.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,10 +32,7 @@ jobs:
       run: |
         if [ ! -x dist/pac_linux/tools/pac ]
         then
-            echo "dist/pac_linux/tools/pac is not executable" 1>&2
-            exit 2
-        else
-            echo "File has execute permission.  This is not an error, but testing that the GithubActions work as expected." 1>&2
+            echo "dist/pac_linux/tools/pac is not executable.  See \"Refreshing actions in dist folder\" in README.md" 1>&2
             exit 1
         fi
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,14 @@ jobs:
         node-version: 14.x
         registry-url: https://npm.pkg.github.com
 
+    - name: Build and test
+      run: |
+        npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}
+        npm i
+        npm run ci
+      env:
+        AZ_DevOps_Read_PAT: ${{ secrets.AZ_DevOps_Read_PAT }}
+
     - name: Check Execute Permissions
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -35,14 +43,6 @@ jobs:
             echo "dist/pac_linux/tools/pac is not executable.  See \"Refreshing actions in dist folder\" in README.md" 1>&2
             exit 1
         fi
-
-    - name: Build and test
-      run: |
-        npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}
-        npm i
-        npm run ci
-      env:
-        AZ_DevOps_Read_PAT: ${{ secrets.AZ_DevOps_Read_PAT }}
 
     - name: Test create-environment action with username/password
       uses: ./create-environment

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,18 @@ jobs:
         node-version: 14.x
         registry-url: https://npm.pkg.github.com
 
+    - name: Check Execute Permissions
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        if [ ! -x dist/pac_linux/tools/pac ]
+        then
+            echo "dist/pac_linux/tools/pac is not executable" 1>&2
+            exit 2
+        else
+            echo "File has execute permission.  This is not an error, but testing that the GithubActions work as expected." 1>&2
+            exit 1
+        fi
+
     - name: Build and test
       run: |
         npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GPR_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Windows, macOS or Linux:
   ```
   - Create a PAT in GitHub to read packages, and enable SSO for the microsoft organization. Then add it to your *~/.npmrc* file or use the `npm login` command as documented [here](https://docs.github.com/en/packages/guides/configuring-npm-for-use-with-github-packages#authenticating-with-a-personal-access-token). This will only be needed until the `@microsoft/powerplatform-cli-wrapper` repo is made public.
 
+If developing on Linux or macOS, you will also need to install `git-lfs`.  (It is prepackaged with the Git installer for Windows.)  Follow the [instructions here](https://docs.github.com/en/github/managing-large-files/installing-git-large-file-storage) for your environment.
+
 ## Getting Started
 
 Clone, restore modules, build and run:
@@ -95,6 +97,19 @@ gulp
 
 Run ```npm run dist``` and commit and push the updates in the ```./dist``` folder.
 
+If you have updated the Linux PAC package version (especially from a Windows host), double check that the `pac` executable has the execute flag set.  Run
+```bash
+git ls-tree HEAD dist/pac_linux/tools/pac
+```
+and check that the leftmost value should be `100755`.  Example output:
+```bash
+100755 blob 00034fe2fe80faca43030481877760674409d739    dist/pac_linux/tools/pac
+```
+If the file mode does not match, run
+```bash
+git update-index --chmod=+x dist/pac_linux/tools/pac
+```
+prior to commiting the changes.
 ## Details
 
 [CLI command for pac](https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/powerapps-cli#solution)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -162,6 +162,8 @@ async function createDist() {
 
 const recompile = gulp.series(
     clean,
+    // See the README.me for instructions on updating the dist folder when these packages are updated,
+    // especially if you are updating the Linux package from a Windows machine.
     async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI.Core.linux-x64', '1.5.6-daily-21040700', path.resolve(outdir, 'pac_linux')),
     async () => fs.chmod(path.resolve(outdir, 'pac_linux', 'tools', 'pac'), 0o711),
     async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI', '1.5.6-daily-21040700', path.resolve(outdir, 'pac')),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ const path = require('path');
 const pslist = require('ps-list');
 const unzip = require('unzip-stream');
 const { glob } = require('glob');
+const { exec } = require("child_process");
 
 const tsConfigFile = './tsconfig.json';
 const tsconfig = require(tsConfigFile);
@@ -160,12 +161,21 @@ async function createDist() {
         });
 }
 
+// Unzipping the pac program from the nuget package does not set the
+// Execute flag on non-Windows platforms.  Thus, we need to set it ourselves.
+async function setExecuteFlag(path) {
+    // chmod sets the execute flag on the filesystem, but is a no-op on windows
+    fs.chmod(path, 0o711)
+        .then(() =>{
+            // Git tracks the execute flag as well, so make sure we set that *esepcially* on Windows
+            exec("git update-index --chmod=+x " + path);
+        });
+}
+
 const recompile = gulp.series(
     clean,
-    // See the README.me for instructions on updating the dist folder when these packages are updated,
-    // especially if you are updating the Linux package from a Windows machine.
     async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI.Core.linux-x64', '1.5.6-daily-21040700', path.resolve(outdir, 'pac_linux')),
-    async () => fs.chmod(path.resolve(outdir, 'pac_linux', 'tools', 'pac'), 0o711),
+    async () => setExecuteFlag(path.resolve(outdir, 'pac_linux', 'tools', 'pac')),
     async () => nugetInstall('CAP_ISVExp_Tools_Daily', 'Microsoft.PowerApps.CLI', '1.5.6-daily-21040700', path.resolve(outdir, 'pac')),
     async () => nugetInstall('nuget.org', 'Microsoft.CrmSdk.CoreTools', '9.1.0.68', path.resolve(outdir, 'sopa')),
     compile


### PR DESCRIPTION
Updated the README with chmod instructions for the linux executable, and installation of git-lfs for non-windows hosts.