### PR TITLE
Require action.yml to be at least one folder deep when generating dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,10 +146,13 @@ async function createDist() {
     binplace('pac CLI', path.join('pac', 'tools'));
     binplace('pac CLI', path.join('pac_linux', 'tools'));
 
-    glob.sync('**/action.yml', {
+    glob.sync('*/**/action.yml', {
             cwd: __dirname
         })
-        .map(actionYaml => path.basename(path.dirname(actionYaml)))
+        .map(actionYaml => {
+            console.log(actionYaml);
+            return path.basename(path.dirname(actionYaml));
+        })
         .forEach((actionName, idx) => {
             const actionDir = path.resolve(distdir, 'actions', actionName)
             log.info(`package action ${idx} "${actionName}" into ./dist folder (${actionDir})...`);


### PR DESCRIPTION
@penguy-ms brought up a bug that gulp dist was throwing an exception. Because there is an action.yml file in the root, the glob.sync call was thinking that the current folder (".") is an action. By changing the glob.sync to require at least one folder level deep, this should resolve that issue.