### PR TITLE
Output environment-id from create action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,7 +84,7 @@ jobs:
       if: always() # Clean up created environments even on failed run
       uses: ./delete-environment
       with:
-        environment-url: ${{ steps.create-environment.outputs.environment-url }}
+        environment-id: ${{ steps.create-environment.outputs.environment-id }}
         user-name: ${{ env.WF_USERNAME }}
         password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
 

--- a/create-environment/action.yml
+++ b/create-environment/action.yml
@@ -59,6 +59,9 @@ outputs:
   environment-url:
     description: URL of the freshly created environment
 
+  environment-id:
+    description: ID of the freshly created environment
+
 runs:
   using: 'node12'
   main: '../dist/actions/create-environment/index.js'

--- a/delete-environment/action.yml
+++ b/delete-environment/action.yml
@@ -5,7 +5,11 @@ description: 'Power Platform Delete Environment Action'
 inputs:
   environment-url:
     description: 'URL of Power Platform environment to delete; e.g. "https://test-env.crm.dynamics.com"'
-    required: true
+    required: false
+
+  environment-id:
+    description: 'ID of Power Platform environment to delete'
+    required: false
 
   user-name:
     description: 'Power Platform user name to authenticate with, e.g. myname@my-org.onmicrosoft.com. Setting this input makes user-name and password required; specifying alternate "app-id" credential set of inputs will result in an error.'

--- a/dist/actions/create-environment/index.js
+++ b/dist/actions/create-environment/index.js
@@ -430,9 +430,11 @@ function main(factory) {
             const createEnvironmentArgs = ['admin', 'create', '--name', envName, '--region', envRegion, '--type', envType, '--domain', domain];
             const result = yield pac.run(createEnvironmentArgs);
             // HACK TODO: Need structured output from pac CLI to make parsing out of the resulting env URL more robust
-            const resultArray = (_a = result.filter(l => l.length > 0).pop()) === null || _a === void 0 ? void 0 : _a.trim().split(/\s+/);
-            const envUrl = resultArray === null || resultArray === void 0 ? void 0 : resultArray.shift();
-            const envId = resultArray === null || resultArray === void 0 ? void 0 : resultArray.shift();
+            const newEnvDetailColumns = (_a = result
+                .filter(l => l.length > 0)
+                .pop()) === null || _a === void 0 ? void 0 : _a.trim().split(/\s+/);
+            const envUrl = newEnvDetailColumns === null || newEnvDetailColumns === void 0 ? void 0 : newEnvDetailColumns.shift();
+            const envId = newEnvDetailColumns === null || newEnvDetailColumns === void 0 ? void 0 : newEnvDetailColumns.shift();
             core.setOutput('environment-url', envUrl);
             core.setOutput('environment-id', envId);
             core.endGroup();

--- a/dist/actions/create-environment/index.js
+++ b/dist/actions/create-environment/index.js
@@ -430,10 +430,11 @@ function main(factory) {
             const createEnvironmentArgs = ['admin', 'create', '--name', envName, '--region', envRegion, '--type', envType, '--domain', domain];
             const result = yield pac.run(createEnvironmentArgs);
             // HACK TODO: Need structured output from pac CLI to make parsing out of the resulting env URL more robust
-            const envUrl = (_a = result
-                .filter(l => l.length > 0)
-                .pop()) === null || _a === void 0 ? void 0 : _a.trim().split(/\s+/).shift();
+            const resultArray = (_a = result.filter(l => l.length > 0).pop()) === null || _a === void 0 ? void 0 : _a.trim().split(/\s+/);
+            const envUrl = resultArray === null || resultArray === void 0 ? void 0 : resultArray.shift();
+            const envId = resultArray === null || resultArray === void 0 ? void 0 : resultArray.shift();
             core.setOutput('environment-url', envUrl);
+            core.setOutput('environment-id', envId);
             core.endGroup();
         }
         catch (error) {

--- a/dist/actions/delete-environment/index.js
+++ b/dist/actions/delete-environment/index.js
@@ -421,9 +421,19 @@ function main(factory) {
         try {
             core.startGroup('delete-environment:');
             const pac = factory.getRunner('pac', process.cwd());
-            const envUrl = core.getInput('environment-url', { required: true });
+            const envUrl = core.getInput('environment-url', { required: false });
+            const envId = core.getInput('environment-id', { required: false });
             yield new lib_1.AuthHandler(pac).authenticate(lib_1.AuthKind.ADMIN);
-            const deleteEnvArgs = ['admin', 'delete', '--url', envUrl];
+            let deleteEnvArgs;
+            if (envUrl) {
+                deleteEnvArgs = ['admin', 'delete', '--url', envUrl];
+            }
+            else if (envId) {
+                deleteEnvArgs = ['admin', 'delete', '-id', envId];
+            }
+            else {
+                throw new Error("Must provide either environment-id or environment-url!");
+            }
             yield pac.run(deleteEnvArgs);
             core.info('environment deleted');
             core.endGroup();

--- a/src/actions/create-environment/index.ts
+++ b/src/actions/create-environment/index.ts
@@ -24,9 +24,14 @@ export async function main(factory: RunnerFactory): Promise<void> {
         const createEnvironmentArgs = ['admin', 'create', '--name', envName, '--region', envRegion, '--type', envType, '--domain', domain];
         const result = await pac.run(createEnvironmentArgs);
         // HACK TODO: Need structured output from pac CLI to make parsing out of the resulting env URL more robust
-        const resultArray = result.filter(l => l.length > 0).pop()?.trim().split(/\s+/);
-        const envUrl = resultArray?.shift();
-        const envId = resultArray?.shift();
+        const newEnvDetailColumns = result
+                                    .filter(l => l.length > 0)
+                                    .pop()
+                                    ?.trim()
+                                    .split(/\s+/);
+
+        const envUrl = newEnvDetailColumns?.shift();
+        const envId = newEnvDetailColumns?.shift();
         core.setOutput('environment-url', envUrl);
         core.setOutput('environment-id', envId);
         core.endGroup();

--- a/src/actions/create-environment/index.ts
+++ b/src/actions/create-environment/index.ts
@@ -24,13 +24,11 @@ export async function main(factory: RunnerFactory): Promise<void> {
         const createEnvironmentArgs = ['admin', 'create', '--name', envName, '--region', envRegion, '--type', envType, '--domain', domain];
         const result = await pac.run(createEnvironmentArgs);
         // HACK TODO: Need structured output from pac CLI to make parsing out of the resulting env URL more robust
-        const envUrl = result
-            .filter(l => l.length > 0)
-            .pop()
-            ?.trim()
-            .split(/\s+/)
-            .shift();
+        const resultArray = result.filter(l => l.length > 0).pop()?.trim().split(/\s+/);
+        const envUrl = resultArray?.shift();
+        const envId = resultArray?.shift();
         core.setOutput('environment-url', envUrl);
+        core.setOutput('environment-id', envId);
         core.endGroup();
     } catch (error) {
         core.setFailed(`failed: ${error.message}`);

--- a/src/actions/delete-environment/index.ts
+++ b/src/actions/delete-environment/index.ts
@@ -13,10 +13,21 @@ export async function main(factory: RunnerFactory): Promise<void> {
     try {
         core.startGroup('delete-environment:');
         const pac = factory.getRunner('pac', process.cwd());
-        const envUrl = core.getInput('environment-url', { required: true });
+        const envUrl = core.getInput('environment-url', { required: false });
+        const envId = core.getInput('environment-id', { required: false });
         await new AuthHandler(pac).authenticate(AuthKind.ADMIN);
 
-        const deleteEnvArgs = ['admin', 'delete', '--url', envUrl];
+        let deleteEnvArgs;
+        if (envUrl) {
+            deleteEnvArgs = ['admin', 'delete', '--url', envUrl];
+        } else if (envId) {
+            deleteEnvArgs = ['admin', 'delete', '-id', envId];
+        } else {
+            throw new Error(
+                "Must provide either environment-id or environment-url!"
+            );
+        }
+
         await pac.run(deleteEnvArgs);
         core.info('environment deleted');
         core.endGroup();

--- a/src/test/deleteEnvironment.test.ts
+++ b/src/test/deleteEnvironment.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import path = require('path');
-import { forEachOf } from 'async';
 import { expect } from 'chai';
 
 import { main as deleteEnvironment } from '../actions/delete-environment';
@@ -11,33 +10,14 @@ import { ActionInputsEmulator } from './actionInputsEmulator';
 describe('delete-environment#input validation', () => {
     const workDir = path.resolve(__dirname, '..', '..', 'out', 'test');
     const mockFactory: MockedRunners = new MockedRunners(workDir);
-    // TODO: read in params and their required state from the action.yml
-
-    const requiredParams = [
-        { Name: 'environment-url', Value: 'aUrl' }
-    ];
 
     const inputParams = [
         { Name: 'environment-url', Value: 'aUrl' },
+        { Name: 'environment-id', Value: 'envId' },
         { Name: 'user-name', Value: 'aUserName' },
         { Name: 'password-secret', Value: 'aSecret' },
     ];
     const actionInputs = new ActionInputsEmulator(inputParams);
-
-    forEachOf(requiredParams, (inputParam) => {
-        it(`required parameter - ${inputParam.Name}`, async() => {
-            actionInputs.defineInputsExcept(inputParam.Name);
-            let res, err;
-            try {
-                 res = await deleteEnvironment(mockFactory);
-            }
-            catch (error) {
-                err = error;
-            }
-            expect(res).to.be.undefined;
-            expect(err.message).to.match(new RegExp(`required and not supplied: ${inputParam.Name}`));
-        });
-    });
 
     it('call action', async() => {
         actionInputs.defineInputs();


### PR DESCRIPTION
Task 2349920: All GH actions that introduce new environments (e.g. create-env) are also setting a new 'environment-id'