### PR TITLE
fix 0.5.0 regression: action.yml not found error

### DIFF
--- a/dist/actions/backup-environment/index.js
+++ b/dist/actions/backup-environment/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5965,7 +5965,7 @@ const runnerParameters_1 = __nccwpck_require__(7727);
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         const taskParser = new YamlParser_1.YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "backup-environment");
+        const parameterMap = taskParser.getHostParameterEntries('backup-environment');
         core.startGroup('backup-environment:');
         yield actions_1.backupEnvironment({
             credentials: getCredentials_1.default(),
@@ -6047,7 +6047,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6070,7 +6070,7 @@ function isClientCredentialsValid(clientCredentials) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6092,7 +6092,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6129,15 +6129,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6155,6 +6158,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6169,12 +6191,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6192,45 +6214,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -138,8 +138,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -430,8 +430,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -486,7 +486,7 @@ exports.toCommandValue = toCommandValue;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addLeadingZeros;
+exports["default"] = addLeadingZeros;
 
 function addLeadingZeros(number, targetLength) {
   var sign = number < 0 ? '-' : '';
@@ -512,7 +512,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = assign;
+exports["default"] = assign;
 
 function assign(target, dirtyObject) {
   if (target == null) {
@@ -543,7 +543,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = cloneObject;
+exports["default"] = cloneObject;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2631));
 
@@ -566,7 +566,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(289));
 
@@ -1443,7 +1443,7 @@ function formatTimezone(offset, dirtyDelimiter) {
 }
 
 var _default = formatters;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -1457,7 +1457,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(8794));
 
@@ -1545,7 +1545,7 @@ var formatters = {
   }
 };
 var _default = formatters;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -1559,7 +1559,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 function dateLongFormatter(pattern, formatLong) {
   switch (pattern) {
@@ -1657,7 +1657,7 @@ var longFormatters = {
   P: dateTimeLongFormatter
 };
 var _default = longFormatters;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -1671,7 +1671,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getTimezoneOffsetInMilliseconds;
+exports["default"] = getTimezoneOffsetInMilliseconds;
 
 /**
  * Google Chrome as of 67.0.3396.87 introduced timezones with offset that includes seconds.
@@ -1703,7 +1703,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getUTCDayOfYear;
+exports["default"] = getUTCDayOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -1738,7 +1738,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getUTCISOWeekYear;
+exports["default"] = getUTCISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -1785,7 +1785,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getUTCISOWeek;
+exports["default"] = getUTCISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -1823,7 +1823,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getUTCWeekYear;
+exports["default"] = getUTCWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -1882,7 +1882,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getUTCWeek;
+exports["default"] = getUTCWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -1957,7 +1957,7 @@ function throwProtectedError(token, format, input) {
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = requiredArgs;
+exports["default"] = requiredArgs;
 
 function requiredArgs(required, args) {
   if (args.length < required) {
@@ -1978,7 +1978,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setUTCDay;
+exports["default"] = setUTCDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2025,7 +2025,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setUTCISODay;
+exports["default"] = setUTCISODay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2068,7 +2068,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setUTCISOWeek;
+exports["default"] = setUTCISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2104,7 +2104,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setUTCWeek;
+exports["default"] = setUTCWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2140,7 +2140,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfUTCISOWeekYear;
+exports["default"] = startOfUTCISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7170));
 
@@ -2175,7 +2175,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfUTCISOWeek;
+exports["default"] = startOfUTCISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -2209,7 +2209,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfUTCWeekYear;
+exports["default"] = startOfUTCWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2251,7 +2251,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfUTCWeek;
+exports["default"] = startOfUTCWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2296,7 +2296,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = toInteger;
+exports["default"] = toInteger;
 
 function toInteger(dirtyNumber) {
   if (dirtyNumber === null || dirtyNumber === true || dirtyNumber === false) {
@@ -2325,7 +2325,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addBusinessDays;
+exports["default"] = addBusinessDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(403));
 
@@ -2405,7 +2405,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addDays;
+exports["default"] = addDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2468,7 +2468,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addHours;
+exports["default"] = addHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2521,7 +2521,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addISOWeekYears;
+exports["default"] = addISOWeekYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2581,7 +2581,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addMilliseconds;
+exports["default"] = addMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2633,7 +2633,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addMinutes;
+exports["default"] = addMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2686,7 +2686,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addMonths;
+exports["default"] = addMonths;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2775,7 +2775,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addQuarters;
+exports["default"] = addQuarters;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2827,7 +2827,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addSeconds;
+exports["default"] = addSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2878,7 +2878,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addWeeks;
+exports["default"] = addWeeks;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2930,7 +2930,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = addYears;
+exports["default"] = addYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -2981,7 +2981,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = add;
+exports["default"] = add;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6227));
 
@@ -3070,7 +3070,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = areIntervalsOverlapping;
+exports["default"] = areIntervalsOverlapping;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -3203,7 +3203,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = closestIndexTo;
+exports["default"] = closestIndexTo;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -3295,7 +3295,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = closestTo;
+exports["default"] = closestTo;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -3385,7 +3385,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = compareAsc;
+exports["default"] = compareAsc;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -3457,7 +3457,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = compareDesc;
+exports["default"] = compareDesc;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -3674,7 +3674,7 @@ exports.secondsInMinute = secondsInMinute;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = daysToWeeks;
+exports["default"] = daysToWeeks;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -3724,7 +3724,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInBusinessDays;
+exports["default"] = differenceInBusinessDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9920));
 
@@ -3802,7 +3802,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarDays;
+exports["default"] = differenceInCalendarDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7032));
 
@@ -3873,7 +3873,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarISOWeekYears;
+exports["default"] = differenceInCalendarISOWeekYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6991));
 
@@ -3931,7 +3931,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarISOWeeks;
+exports["default"] = differenceInCalendarISOWeeks;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7032));
 
@@ -3995,7 +3995,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarMonths;
+exports["default"] = differenceInCalendarMonths;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4050,7 +4050,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarQuarters;
+exports["default"] = differenceInCalendarQuarters;
 
 var _index = _interopRequireDefault(__nccwpck_require__(4523));
 
@@ -4107,7 +4107,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarWeeks;
+exports["default"] = differenceInCalendarWeeks;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9813));
 
@@ -4183,7 +4183,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInCalendarYears;
+exports["default"] = differenceInCalendarYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4236,7 +4236,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInDays;
+exports["default"] = differenceInDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4344,7 +4344,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInHours;
+exports["default"] = differenceInHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2288));
 
@@ -4398,7 +4398,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInISOWeekYears;
+exports["default"] = differenceInISOWeekYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4473,7 +4473,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInMilliseconds;
+exports["default"] = differenceInMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4527,7 +4527,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInMinutes;
+exports["default"] = differenceInMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2288));
 
@@ -4589,7 +4589,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInMonths;
+exports["default"] = differenceInMonths;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4671,7 +4671,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInQuarters;
+exports["default"] = differenceInQuarters;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2713));
 
@@ -4720,7 +4720,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInSeconds;
+exports["default"] = differenceInSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2288));
 
@@ -4773,7 +4773,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInWeeks;
+exports["default"] = differenceInWeeks;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6311));
 
@@ -4843,7 +4843,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = differenceInYears;
+exports["default"] = differenceInYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -4908,7 +4908,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachDayOfInterval;
+exports["default"] = eachDayOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -5016,7 +5016,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachHourOfInterval;
+exports["default"] = eachHourOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9956));
 
@@ -5095,7 +5095,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachMinuteOfInterval;
+exports["default"] = eachMinuteOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(5268));
 
@@ -5174,7 +5174,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachMonthOfInterval;
+exports["default"] = eachMonthOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -5249,7 +5249,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachQuarterOfInterval;
+exports["default"] = eachQuarterOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(5149));
 
@@ -5325,7 +5325,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachWeekOfInterval;
+exports["default"] = eachWeekOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7195));
 
@@ -5419,7 +5419,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachWeekendOfInterval;
+exports["default"] = eachWeekendOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6545));
 
@@ -5489,7 +5489,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachWeekendOfMonth;
+exports["default"] = eachWeekendOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1944));
 
@@ -5552,7 +5552,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachWeekendOfYear;
+exports["default"] = eachWeekendOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1944));
 
@@ -5612,7 +5612,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = eachYearOfInterval;
+exports["default"] = eachYearOfInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -5684,7 +5684,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfDay;
+exports["default"] = endOfDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -5734,7 +5734,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfDecade;
+exports["default"] = endOfDecade;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -5789,7 +5789,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfHour;
+exports["default"] = endOfHour;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -5839,7 +5839,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfISOWeekYear;
+exports["default"] = endOfISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6991));
 
@@ -5903,7 +5903,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfISOWeek;
+exports["default"] = endOfISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(5218));
 
@@ -5955,7 +5955,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfMinute;
+exports["default"] = endOfMinute;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -6005,7 +6005,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfMonth;
+exports["default"] = endOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -6057,7 +6057,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfQuarter;
+exports["default"] = endOfQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -6110,7 +6110,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfSecond;
+exports["default"] = endOfSecond;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -6160,7 +6160,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfToday;
+exports["default"] = endOfToday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(8569));
 
@@ -6206,7 +6206,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfTomorrow;
+exports["default"] = endOfTomorrow;
 
 /**
  * @name endOfTomorrow
@@ -6255,7 +6255,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfWeek;
+exports["default"] = endOfWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -6329,7 +6329,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfYear;
+exports["default"] = endOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -6381,7 +6381,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = endOfYesterday;
+exports["default"] = endOfYesterday;
 
 /**
  * @name endOfYesterday
@@ -6430,7 +6430,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatDistanceStrict;
+exports["default"] = formatDistanceStrict;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7032));
 
@@ -6706,7 +6706,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatDistanceToNowStrict;
+exports["default"] = formatDistanceToNowStrict;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7128));
 
@@ -6806,7 +6806,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatDistanceToNow;
+exports["default"] = formatDistanceToNow;
 
 var _index = _interopRequireDefault(__nccwpck_require__(8149));
 
@@ -6937,7 +6937,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatDistance;
+exports["default"] = formatDistance;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9818));
 
@@ -7176,7 +7176,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatDuration;
+exports["default"] = formatDuration;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1773));
 
@@ -7279,7 +7279,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatISO9075;
+exports["default"] = formatISO9075;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -7389,7 +7389,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatISODuration;
+exports["default"] = formatISODuration;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -7452,7 +7452,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatISO;
+exports["default"] = formatISO;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -7579,7 +7579,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatRFC3339;
+exports["default"] = formatRFC3339;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -7684,7 +7684,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatRFC7231;
+exports["default"] = formatRFC7231;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -7751,7 +7751,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatRelative;
+exports["default"] = formatRelative;
 
 var _index = _interopRequireDefault(__nccwpck_require__(3086));
 
@@ -7876,7 +7876,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = format;
+exports["default"] = format;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9920));
 
@@ -8337,7 +8337,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = fromUnixTime;
+exports["default"] = fromUnixTime;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8387,7 +8387,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getDate;
+exports["default"] = getDate;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8436,7 +8436,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getDayOfYear;
+exports["default"] = getDayOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8490,7 +8490,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getDay;
+exports["default"] = getDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8539,7 +8539,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getDaysInMonth;
+exports["default"] = getDaysInMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8592,7 +8592,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getDaysInYear;
+exports["default"] = getDaysInYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8647,7 +8647,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getDecade;
+exports["default"] = getDecade;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8697,7 +8697,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getHours;
+exports["default"] = getHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8746,7 +8746,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getISODay;
+exports["default"] = getISODay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8803,7 +8803,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getISOWeekYear;
+exports["default"] = getISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8877,7 +8877,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getISOWeek;
+exports["default"] = getISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -8937,7 +8937,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getISOWeeksInYear;
+exports["default"] = getISOWeeksInYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(776));
 
@@ -8996,7 +8996,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getMilliseconds;
+exports["default"] = getMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9045,7 +9045,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getMinutes;
+exports["default"] = getMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9094,7 +9094,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getMonth;
+exports["default"] = getMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9143,7 +9143,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getOverlappingDaysInIntervals;
+exports["default"] = getOverlappingDaysInIntervals;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9256,7 +9256,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getQuarter;
+exports["default"] = getQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9305,7 +9305,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getSeconds;
+exports["default"] = getSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9354,7 +9354,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getTime;
+exports["default"] = getTime;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9403,7 +9403,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getUnixTime;
+exports["default"] = getUnixTime;
 
 var _index = _interopRequireDefault(__nccwpck_require__(5052));
 
@@ -9450,7 +9450,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getWeekOfMonth;
+exports["default"] = getWeekOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7626));
 
@@ -9539,7 +9539,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getWeekYear;
+exports["default"] = getWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9813));
 
@@ -9639,7 +9639,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getWeek;
+exports["default"] = getWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9813));
 
@@ -9718,7 +9718,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getWeeksInMonth;
+exports["default"] = getWeeksInMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(8620));
 
@@ -9779,7 +9779,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = getYear;
+exports["default"] = getYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -9828,7 +9828,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = hoursToMilliseconds;
+exports["default"] = hoursToMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -9872,7 +9872,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = hoursToMinutes;
+exports["default"] = hoursToMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -9916,7 +9916,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = hoursToSeconds;
+exports["default"] = hoursToSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -12032,7 +12032,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = intervalToDuration;
+exports["default"] = intervalToDuration;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9818));
 
@@ -12142,7 +12142,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = intlFormat;
+exports["default"] = intlFormat;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -12250,7 +12250,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isAfter;
+exports["default"] = isAfter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12300,7 +12300,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isBefore;
+exports["default"] = isBefore;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12350,7 +12350,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isDate;
+exports["default"] = isDate;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -12410,7 +12410,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isEqual;
+exports["default"] = isEqual;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12463,7 +12463,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isExists;
+exports["default"] = isExists;
 
 /**
  * @name isExists
@@ -12511,7 +12511,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isFirstDayOfMonth;
+exports["default"] = isFirstDayOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12558,7 +12558,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isFriday;
+exports["default"] = isFriday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12605,7 +12605,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isFuture;
+exports["default"] = isFuture;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12656,7 +12656,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isLastDayOfMonth;
+exports["default"] = isLastDayOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12708,7 +12708,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isLeapYear;
+exports["default"] = isLeapYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -12757,7 +12757,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isMatch;
+exports["default"] = isMatch;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1287));
 
@@ -13077,7 +13077,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isMonday;
+exports["default"] = isMonday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -13124,7 +13124,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isPast;
+exports["default"] = isPast;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -13175,7 +13175,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameDay;
+exports["default"] = isSameDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1868));
 
@@ -13225,7 +13225,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameHour;
+exports["default"] = isSameHour;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6277));
 
@@ -13275,7 +13275,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameISOWeekYear;
+exports["default"] = isSameISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(776));
 
@@ -13332,7 +13332,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameISOWeek;
+exports["default"] = isSameISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7013));
 
@@ -13384,7 +13384,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameMinute;
+exports["default"] = isSameMinute;
 
 var _index = _interopRequireDefault(__nccwpck_require__(8567));
 
@@ -13438,7 +13438,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameMonth;
+exports["default"] = isSameMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -13488,7 +13488,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameQuarter;
+exports["default"] = isSameQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2932));
 
@@ -13538,7 +13538,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameSecond;
+exports["default"] = isSameSecond;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6738));
 
@@ -13592,7 +13592,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameWeek;
+exports["default"] = isSameWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9813));
 
@@ -13654,7 +13654,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSameYear;
+exports["default"] = isSameYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -13704,7 +13704,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSaturday;
+exports["default"] = isSaturday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -13751,7 +13751,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isSunday;
+exports["default"] = isSunday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -13798,7 +13798,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisHour;
+exports["default"] = isThisHour;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2489));
 
@@ -13850,7 +13850,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisISOWeek;
+exports["default"] = isThisISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9852));
 
@@ -13903,7 +13903,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisMinute;
+exports["default"] = isThisMinute;
 
 var _index = _interopRequireDefault(__nccwpck_require__(3197));
 
@@ -13955,7 +13955,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisMonth;
+exports["default"] = isThisMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(5421));
 
@@ -14006,7 +14006,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisQuarter;
+exports["default"] = isThisQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(938));
 
@@ -14057,7 +14057,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisSecond;
+exports["default"] = isThisSecond;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1988));
 
@@ -14109,7 +14109,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisWeek;
+exports["default"] = isThisWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(7013));
 
@@ -14170,7 +14170,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThisYear;
+exports["default"] = isThisYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9821));
 
@@ -14221,7 +14221,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isThursday;
+exports["default"] = isThursday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14268,7 +14268,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isToday;
+exports["default"] = isToday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2154));
 
@@ -14319,7 +14319,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isTomorrow;
+exports["default"] = isTomorrow;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6227));
 
@@ -14372,7 +14372,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isTuesday;
+exports["default"] = isTuesday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14419,7 +14419,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isValid;
+exports["default"] = isValid;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14503,7 +14503,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isWednesday;
+exports["default"] = isWednesday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14550,7 +14550,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isWeekend;
+exports["default"] = isWeekend;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14599,7 +14599,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isWithinInterval;
+exports["default"] = isWithinInterval;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14706,7 +14706,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = isYesterday;
+exports["default"] = isYesterday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2154));
 
@@ -14759,7 +14759,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfDecade;
+exports["default"] = lastDayOfDecade;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14811,7 +14811,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfISOWeekYear;
+exports["default"] = lastDayOfISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6991));
 
@@ -14875,7 +14875,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfISOWeek;
+exports["default"] = lastDayOfISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(666));
 
@@ -14927,7 +14927,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfMonth;
+exports["default"] = lastDayOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -14979,7 +14979,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfQuarter;
+exports["default"] = lastDayOfQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -15035,7 +15035,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfWeek;
+exports["default"] = lastDayOfWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -15109,7 +15109,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lastDayOfYear;
+exports["default"] = lastDayOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -15161,7 +15161,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = lightFormat;
+exports["default"] = lightFormat;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -15312,7 +15312,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = buildFormatLongFn;
+exports["default"] = buildFormatLongFn;
 
 function buildFormatLongFn(args) {
   return function (dirtyOptions) {
@@ -15336,7 +15336,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = buildLocalizeFn;
+exports["default"] = buildLocalizeFn;
 
 function buildLocalizeFn(args) {
   return function (dirtyIndex, dirtyOptions) {
@@ -15374,7 +15374,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = buildMatchFn;
+exports["default"] = buildMatchFn;
 
 function buildMatchFn(args) {
   return function (dirtyString, dirtyOptions) {
@@ -15440,7 +15440,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = buildMatchPatternFn;
+exports["default"] = buildMatchPatternFn;
 
 function buildMatchPatternFn(args) {
   return function (dirtyString, dirtyOptions) {
@@ -15481,7 +15481,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatDistance;
+exports["default"] = formatDistance;
 var formatDistanceLocale = {
   lessThanXSeconds: {
     one: 'less than a second',
@@ -15582,7 +15582,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1244));
 
@@ -15621,7 +15621,7 @@ var formatLong = {
   })
 };
 var _default = formatLong;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -15635,7 +15635,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = formatRelative;
+exports["default"] = formatRelative;
 var formatRelativeLocale = {
   lastWeek: "'last' eeee 'at' p",
   yesterday: "'yesterday at' p",
@@ -15662,7 +15662,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(3647));
 
@@ -15816,7 +15816,7 @@ var localize = {
   })
 };
 var _default = localize;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -15830,7 +15830,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(3364));
 
@@ -15934,7 +15934,7 @@ var match = {
   })
 };
 var _default = match;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -15948,7 +15948,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(4846));
 
@@ -15986,7 +15986,7 @@ var locale = {
   }
 };
 var _default = locale;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -16000,7 +16000,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = max;
+exports["default"] = max;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -16084,7 +16084,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = millisecondsToHours;
+exports["default"] = millisecondsToHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16134,7 +16134,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = millisecondsToMinutes;
+exports["default"] = millisecondsToMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16184,7 +16184,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = millisecondsToSeconds;
+exports["default"] = millisecondsToSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16234,7 +16234,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = milliseconds;
+exports["default"] = milliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16307,7 +16307,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = min;
+exports["default"] = min;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -16391,7 +16391,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = minutesToHours;
+exports["default"] = minutesToHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16441,7 +16441,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = minutesToMilliseconds;
+exports["default"] = minutesToMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16485,7 +16485,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = minutesToSeconds;
+exports["default"] = minutesToSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16529,7 +16529,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = monthsToQuarters;
+exports["default"] = monthsToQuarters;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16579,7 +16579,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = monthsToYears;
+exports["default"] = monthsToYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16628,7 +16628,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextDay;
+exports["default"] = nextDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16694,7 +16694,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextFriday;
+exports["default"] = nextFriday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16739,7 +16739,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextMonday;
+exports["default"] = nextMonday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16784,7 +16784,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextSaturday;
+exports["default"] = nextSaturday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16829,7 +16829,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextSunday;
+exports["default"] = nextSunday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16874,7 +16874,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextThursday;
+exports["default"] = nextThursday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16919,7 +16919,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextTuesday;
+exports["default"] = nextTuesday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -16964,7 +16964,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = nextWednesday;
+exports["default"] = nextWednesday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -17009,7 +17009,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = parseISO;
+exports["default"] = parseISO;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -17320,7 +17320,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = parseJSON;
+exports["default"] = parseJSON;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -17392,7 +17392,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _index = _interopRequireDefault(__nccwpck_require__(8050));
 
@@ -18906,7 +18906,7 @@ var parsers = {
   }
 };
 var _default = parsers;
-exports.default = _default;
+exports["default"] = _default;
 module.exports = exports.default;
 
 /***/ }),
@@ -18920,7 +18920,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = parse;
+exports["default"] = parse;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1773));
 
@@ -19499,7 +19499,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = quartersToMonths;
+exports["default"] = quartersToMonths;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -19543,7 +19543,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = quartersToYears;
+exports["default"] = quartersToYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -19593,7 +19593,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = roundToNearestMinutes;
+exports["default"] = roundToNearestMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -19666,7 +19666,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = secondsToHours;
+exports["default"] = secondsToHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -19716,7 +19716,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = secondsToMilliseconds;
+exports["default"] = secondsToMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -19760,7 +19760,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = secondsToMinutes;
+exports["default"] = secondsToMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -19810,7 +19810,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setDate;
+exports["default"] = setDate;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -19863,7 +19863,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setDayOfYear;
+exports["default"] = setDayOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -19917,7 +19917,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setDay;
+exports["default"] = setDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6227));
 
@@ -19995,7 +19995,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setHours;
+exports["default"] = setHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20048,7 +20048,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setISODay;
+exports["default"] = setISODay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20108,7 +20108,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setISOWeekYear;
+exports["default"] = setISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20178,7 +20178,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setISOWeek;
+exports["default"] = setISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20236,7 +20236,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setMilliseconds;
+exports["default"] = setMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20289,7 +20289,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setMinutes;
+exports["default"] = setMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20342,7 +20342,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setMonth;
+exports["default"] = setMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20405,7 +20405,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setQuarter;
+exports["default"] = setQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20461,7 +20461,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setSeconds;
+exports["default"] = setSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20514,7 +20514,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setWeekYear;
+exports["default"] = setWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(3086));
 
@@ -20604,7 +20604,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setWeek;
+exports["default"] = setWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(81));
 
@@ -20682,7 +20682,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = setYear;
+exports["default"] = setYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -20740,7 +20740,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = set;
+exports["default"] = set;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -20847,7 +20847,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfDay;
+exports["default"] = startOfDay;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -20897,7 +20897,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfDecade;
+exports["default"] = startOfDecade;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -20949,7 +20949,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfHour;
+exports["default"] = startOfHour;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -20999,7 +20999,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfISOWeekYear;
+exports["default"] = startOfISOWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6991));
 
@@ -21057,7 +21057,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfISOWeek;
+exports["default"] = startOfISOWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(9813));
 
@@ -21109,7 +21109,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfMinute;
+exports["default"] = startOfMinute;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -21159,7 +21159,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfMonth;
+exports["default"] = startOfMonth;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -21210,7 +21210,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfQuarter;
+exports["default"] = startOfQuarter;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -21263,7 +21263,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfSecond;
+exports["default"] = startOfSecond;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -21313,7 +21313,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfToday;
+exports["default"] = startOfToday;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1868));
 
@@ -21359,7 +21359,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfTomorrow;
+exports["default"] = startOfTomorrow;
 
 /**
  * @name startOfTomorrow
@@ -21408,7 +21408,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfWeekYear;
+exports["default"] = startOfWeekYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(3494));
 
@@ -21491,7 +21491,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfWeek;
+exports["default"] = startOfWeek;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -21565,7 +21565,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfYear;
+exports["default"] = startOfYear;
 
 var _index = _interopRequireDefault(__nccwpck_require__(6477));
 
@@ -21617,7 +21617,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = startOfYesterday;
+exports["default"] = startOfYesterday;
 
 /**
  * @name startOfYesterday
@@ -21666,7 +21666,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subBusinessDays;
+exports["default"] = subBusinessDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -21713,7 +21713,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subDays;
+exports["default"] = subDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -21764,7 +21764,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subHours;
+exports["default"] = subHours;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -21815,7 +21815,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subISOWeekYears;
+exports["default"] = subISOWeekYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -21873,7 +21873,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subMilliseconds;
+exports["default"] = subMilliseconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -21924,7 +21924,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subMinutes;
+exports["default"] = subMinutes;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -21975,7 +21975,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subMonths;
+exports["default"] = subMonths;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -22026,7 +22026,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subQuarters;
+exports["default"] = subQuarters;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -22077,7 +22077,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subSeconds;
+exports["default"] = subSeconds;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -22128,7 +22128,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subWeeks;
+exports["default"] = subWeeks;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -22179,7 +22179,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = subYears;
+exports["default"] = subYears;
 
 var _index = _interopRequireDefault(__nccwpck_require__(1985));
 
@@ -22230,7 +22230,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = sub;
+exports["default"] = sub;
 
 var _index = _interopRequireDefault(__nccwpck_require__(970));
 
@@ -22318,7 +22318,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = toDate;
+exports["default"] = toDate;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -22388,7 +22388,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = weeksToDays;
+exports["default"] = weeksToDays;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -22432,7 +22432,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = yearsToMonths;
+exports["default"] = yearsToMonths;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -22476,7 +22476,7 @@ module.exports = exports.default;
 Object.defineProperty(exports, "__esModule", ({
   value: true
 }));
-exports.default = yearsToQuarters;
+exports["default"] = yearsToQuarters;
 
 var _index = _interopRequireDefault(__nccwpck_require__(2063));
 
@@ -22518,9 +22518,9 @@ module.exports = exports.default;
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const mkdirsSync = __nccwpck_require__(8605).mkdirsSync
-const utimesMillisSync = __nccwpck_require__(2548).utimesMillisSync
+const path = __nccwpck_require__(1017)
+const mkdirsSync = (__nccwpck_require__(8605).mkdirsSync)
+const utimesMillisSync = (__nccwpck_require__(2548).utimesMillisSync)
 const stat = __nccwpck_require__(3901)
 
 function copySync (src, dest, opts) {
@@ -22705,10 +22705,10 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const mkdirs = __nccwpck_require__(8605).mkdirs
-const pathExists = __nccwpck_require__(3835).pathExists
-const utimesMillis = __nccwpck_require__(2548).utimesMillis
+const path = __nccwpck_require__(1017)
+const mkdirs = (__nccwpck_require__(8605).mkdirs)
+const pathExists = (__nccwpck_require__(3835).pathExists)
+const utimesMillis = (__nccwpck_require__(2548).utimesMillis)
 const stat = __nccwpck_require__(3901)
 
 function copy (src, dest, opts, cb) {
@@ -22944,7 +22944,7 @@ module.exports = copy
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 module.exports = {
   copy: u(__nccwpck_require__(8834))
 }
@@ -22958,9 +22958,9 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const fs = __nccwpck_require__(1176)
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 const mkdir = __nccwpck_require__(8605)
 const remove = __nccwpck_require__(7357)
 
@@ -23005,8 +23005,8 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
-const path = __nccwpck_require__(5622)
+const u = (__nccwpck_require__(9046).fromCallback)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7758)
 const mkdir = __nccwpck_require__(8605)
 
@@ -23113,11 +23113,11 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
-const path = __nccwpck_require__(5622)
+const u = (__nccwpck_require__(9046).fromCallback)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7758)
 const mkdir = __nccwpck_require__(8605)
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 const { areIdentical } = __nccwpck_require__(3901)
 
 function createLink (srcpath, dstpath, callback) {
@@ -23185,9 +23185,9 @@ module.exports = {
 "use strict";
 
 
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7758)
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 /**
  * Function that returns two types of paths, one relative to symlink, and one
@@ -23331,8 +23331,8 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
-const path = __nccwpck_require__(5622)
+const u = (__nccwpck_require__(9046).fromCallback)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(1176)
 const _mkdirs = __nccwpck_require__(8605)
 const mkdirs = _mkdirs.mkdirs
@@ -23346,7 +23346,7 @@ const _symlinkType = __nccwpck_require__(8254)
 const symlinkType = _symlinkType.symlinkType
 const symlinkTypeSync = _symlinkType.symlinkTypeSync
 
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 const { areIdentical } = __nccwpck_require__(3901)
 
@@ -23422,7 +23422,7 @@ module.exports = {
 
 // This is adapted from https://github.com/normalize/mz
 // Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 const fs = __nccwpck_require__(7758)
 
 const api = [
@@ -23574,7 +23574,7 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const jsonFile = __nccwpck_require__(8970)
 
 jsonFile.outputJson = u(__nccwpck_require__(531))
@@ -23656,7 +23656,7 @@ module.exports = outputJson
 
 "use strict";
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const { makeDir: _makeDir, makeDirSync } = __nccwpck_require__(2751)
 const makeDir = u(_makeDir)
 
@@ -23718,7 +23718,7 @@ module.exports.makeDirSync = (dir, options) => {
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 
 // https://github.com/nodejs/node/issues/8987
 // https://github.com/libuv/libuv/pull/1088
@@ -23757,10 +23757,10 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const copySync = __nccwpck_require__(1135).copySync
-const removeSync = __nccwpck_require__(7357).removeSync
-const mkdirpSync = __nccwpck_require__(8605).mkdirpSync
+const path = __nccwpck_require__(1017)
+const copySync = (__nccwpck_require__(1135).copySync)
+const removeSync = (__nccwpck_require__(7357).removeSync)
+const mkdirpSync = (__nccwpck_require__(8605).mkdirpSync)
 const stat = __nccwpck_require__(3901)
 
 function moveSync (src, dest, opts) {
@@ -23818,7 +23818,7 @@ module.exports = moveSync
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 module.exports = {
   move: u(__nccwpck_require__(2231))
 }
@@ -23833,11 +23833,11 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const copy = __nccwpck_require__(1335).copy
-const remove = __nccwpck_require__(7357).remove
-const mkdirp = __nccwpck_require__(8605).mkdirp
-const pathExists = __nccwpck_require__(3835).pathExists
+const path = __nccwpck_require__(1017)
+const copy = (__nccwpck_require__(1335).copy)
+const remove = (__nccwpck_require__(7357).remove)
+const mkdirp = (__nccwpck_require__(8605).mkdirp)
+const pathExists = (__nccwpck_require__(3835).pathExists)
 const stat = __nccwpck_require__(3901)
 
 function move (src, dest, opts, cb) {
@@ -23913,11 +23913,11 @@ module.exports = move
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 const mkdir = __nccwpck_require__(8605)
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 function outputFile (file, data, encoding, callback) {
   if (typeof encoding === 'function') {
@@ -23960,7 +23960,7 @@ module.exports = {
 
 "use strict";
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const fs = __nccwpck_require__(1176)
 
 function pathExists (path) {
@@ -23982,7 +23982,7 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 const rimraf = __nccwpck_require__(7247)
 
 function remove (path, callback) {
@@ -24012,8 +24012,8 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const assert = __nccwpck_require__(2357)
+const path = __nccwpck_require__(1017)
+const assert = __nccwpck_require__(9491)
 
 const isWindows = (process.platform === 'win32')
 
@@ -24322,8 +24322,8 @@ rimraf.sync = rimrafSync
 
 
 const fs = __nccwpck_require__(1176)
-const path = __nccwpck_require__(5622)
-const util = __nccwpck_require__(1669)
+const path = __nccwpck_require__(1017)
+const util = __nccwpck_require__(3837)
 
 function getStats (src, dest, opts) {
   const statFunc = opts.dereference
@@ -24545,12 +24545,12 @@ function clone (obj) {
 /***/ 7758:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var fs = __nccwpck_require__(5747)
+var fs = __nccwpck_require__(7147)
 var polyfills = __nccwpck_require__(263)
 var legacy = __nccwpck_require__(5162)
 var clone = __nccwpck_require__(7356)
 
-var util = __nccwpck_require__(1669)
+var util = __nccwpck_require__(3837)
 
 /* istanbul ignore next - node 0.x polyfill */
 var gracefulQueue
@@ -24631,7 +24631,7 @@ if (!fs[gracefulQueue]) {
   if (/\bgfs4\b/i.test(process.env.NODE_DEBUG || '')) {
     process.on('exit', function() {
       debug(fs[gracefulQueue])
-      __nccwpck_require__(2357).equal(fs[gracefulQueue].length, 0)
+      __nccwpck_require__(9491).equal(fs[gracefulQueue].length, 0)
     })
   }
 }
@@ -24925,7 +24925,7 @@ function retry () {
 /***/ 5162:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Stream = __nccwpck_require__(2413).Stream
+var Stream = (__nccwpck_require__(2781).Stream)
 
 module.exports = legacy
 
@@ -25050,7 +25050,7 @@ function legacy (fs) {
 /***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var constants = __nccwpck_require__(7619)
+var constants = __nccwpck_require__(2057)
 
 var origCwd = process.cwd
 var cwd = null
@@ -25407,7 +25407,7 @@ let _fs
 try {
   _fs = __nccwpck_require__(7758)
 } catch (_) {
-  _fs = __nccwpck_require__(5747)
+  _fs = __nccwpck_require__(7147)
 }
 const universalify = __nccwpck_require__(9046)
 const { stringify, stripBom } = __nccwpck_require__(5902)
@@ -25569,8 +25569,8 @@ const core = __nccwpck_require__(2186);
 const lib_1 = __nccwpck_require__(2806);
 const date_fns_1 = __nccwpck_require__(3314);
 const fs = __nccwpck_require__(5630);
-const path = __nccwpck_require__(5622);
-const process_1 = __nccwpck_require__(1765);
+const path = __nccwpck_require__(1017);
+const process_1 = __nccwpck_require__(7282);
 core.startGroup('create-solution-pr:');
 const logger = new lib_1.ActionLogger();
 const workingDir = lib_1.getWorkingDirectory('working-directory', false);
@@ -25936,7 +25936,7 @@ function createLegacyRunnerPacAuthenticator(pac) {
         });
     }
 }
-exports.default = createLegacyRunnerPacAuthenticator;
+exports["default"] = createLegacyRunnerPacAuthenticator;
 
 //# sourceMappingURL=createLegacyRunnerPacAuthenticator.js.map
 
@@ -25953,7 +25953,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -25978,11 +25978,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.ExeRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const child_process_1 = __nccwpck_require__(3129);
-const os = __nccwpck_require__(2087);
+const child_process_1 = __nccwpck_require__(2081);
+const os = __nccwpck_require__(2037);
 const getExePath_1 = __nccwpck_require__(309);
 const runnerParameters_1 = __nccwpck_require__(7727);
-const process = __nccwpck_require__(1765);
+const process = __nccwpck_require__(7282);
 class ExeRunner {
     constructor(_workingDir, logger, exeName, exeRelativePath) {
         this._workingDir = _workingDir;
@@ -26067,7 +26067,7 @@ exports.RunnerError = RunnerError;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -26089,7 +26089,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -26132,7 +26132,7 @@ Object.defineProperty(exports, "getInputAsBool", ({ enumerable: true, get: funct
 Object.defineProperty(exports, "getWorkingDirectory", ({ enumerable: true, get: function () { return actionInput_1.getWorkingDirectory; } }));
 var exeRunner_1 = __nccwpck_require__(7021);
 Object.defineProperty(exports, "RunnerError", ({ enumerable: true, get: function () { return exeRunner_1.RunnerError; } }));
-var runnerFactory_1 = __nccwpck_require__(7147);
+var runnerFactory_1 = __nccwpck_require__(7597);
 Object.defineProperty(exports, "DefaultRunnerFactory", ({ enumerable: true, get: function () { return runnerFactory_1.DefaultRunnerFactory; } }));
 // TODO: delete exports once all actions are converted:
 var actionLogger_1 = __nccwpck_require__(3970);
@@ -26160,7 +26160,7 @@ exports.PacRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const exeRunner_1 = __nccwpck_require__(7021);
-const os = __nccwpck_require__(2087);
+const os = __nccwpck_require__(2037);
 const platform = os.platform();
 const programName = platform === "win32" ? 'pac.exe' : 'pac';
 const programPath = platform === "win32" ? ['pac', 'tools'] : ['pac_linux', 'tools'];
@@ -26176,7 +26176,7 @@ exports.PacRunner = PacRunner;
 
 /***/ }),
 
-/***/ 7147:
+/***/ 7597:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26217,12 +26217,12 @@ exports.DefaultRunnerFactory = new RealRunnerFactory();
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -26240,15 +26240,7 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-"use strict";
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 2357:
+/***/ 9491:
 /***/ ((module) => {
 
 "use strict";
@@ -26256,7 +26248,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 "use strict";
@@ -26264,7 +26256,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 7619:
+/***/ 2057:
 /***/ ((module) => {
 
 "use strict";
@@ -26272,7 +26264,7 @@ module.exports = require("constants");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 "use strict";
@@ -26280,7 +26272,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 "use strict";
@@ -26288,7 +26280,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 "use strict";
@@ -26296,7 +26288,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 "use strict";
@@ -26304,7 +26296,7 @@ module.exports = require("process");
 
 /***/ }),
 
-/***/ 2413:
+/***/ 2781:
 /***/ ((module) => {
 
 "use strict";
@@ -26312,11 +26304,19 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 1669:
+/***/ 3837:
 /***/ ((module) => {
 
 "use strict";
 module.exports = require("util");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+"use strict";
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/check-solution/index.js
+++ b/dist/actions/check-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5956,7 +5956,7 @@ const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     core.startGroup('check-solution:');
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "check-solution");
+    const parameterMap = taskParser.getHostParameterEntries('check-solution');
     yield actions_1.checkSolution({
         credentials: getCredentials_1.default(),
         environmentUrl: getEnvironmentUrl_1.default(),
@@ -6041,7 +6041,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6068,7 +6068,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6080,7 +6080,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6102,7 +6102,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6139,15 +6139,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6165,6 +6168,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6179,12 +6201,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6202,45 +6224,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/clone-solution/index.js
+++ b/dist/actions/clone-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -138,8 +138,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -430,8 +430,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -484,9 +484,9 @@ exports.toCommandValue = toCommandValue;
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const mkdirsSync = __nccwpck_require__(8605).mkdirsSync
-const utimesMillisSync = __nccwpck_require__(2548).utimesMillisSync
+const path = __nccwpck_require__(1017)
+const mkdirsSync = (__nccwpck_require__(8605).mkdirsSync)
+const utimesMillisSync = (__nccwpck_require__(2548).utimesMillisSync)
 const stat = __nccwpck_require__(3901)
 
 function copySync (src, dest, opts) {
@@ -671,10 +671,10 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const mkdirs = __nccwpck_require__(8605).mkdirs
-const pathExists = __nccwpck_require__(3835).pathExists
-const utimesMillis = __nccwpck_require__(2548).utimesMillis
+const path = __nccwpck_require__(1017)
+const mkdirs = (__nccwpck_require__(8605).mkdirs)
+const pathExists = (__nccwpck_require__(3835).pathExists)
+const utimesMillis = (__nccwpck_require__(2548).utimesMillis)
 const stat = __nccwpck_require__(3901)
 
 function copy (src, dest, opts, cb) {
@@ -910,7 +910,7 @@ module.exports = copy
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 module.exports = {
   copy: u(__nccwpck_require__(8834))
 }
@@ -924,9 +924,9 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const fs = __nccwpck_require__(1176)
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 const mkdir = __nccwpck_require__(8605)
 const remove = __nccwpck_require__(7357)
 
@@ -971,8 +971,8 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
-const path = __nccwpck_require__(5622)
+const u = (__nccwpck_require__(9046).fromCallback)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7758)
 const mkdir = __nccwpck_require__(8605)
 
@@ -1079,11 +1079,11 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
-const path = __nccwpck_require__(5622)
+const u = (__nccwpck_require__(9046).fromCallback)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7758)
 const mkdir = __nccwpck_require__(8605)
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 const { areIdentical } = __nccwpck_require__(3901)
 
 function createLink (srcpath, dstpath, callback) {
@@ -1151,9 +1151,9 @@ module.exports = {
 "use strict";
 
 
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(7758)
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 /**
  * Function that returns two types of paths, one relative to symlink, and one
@@ -1297,8 +1297,8 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
-const path = __nccwpck_require__(5622)
+const u = (__nccwpck_require__(9046).fromCallback)
+const path = __nccwpck_require__(1017)
 const fs = __nccwpck_require__(1176)
 const _mkdirs = __nccwpck_require__(8605)
 const mkdirs = _mkdirs.mkdirs
@@ -1312,7 +1312,7 @@ const _symlinkType = __nccwpck_require__(8254)
 const symlinkType = _symlinkType.symlinkType
 const symlinkTypeSync = _symlinkType.symlinkTypeSync
 
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 const { areIdentical } = __nccwpck_require__(3901)
 
@@ -1388,7 +1388,7 @@ module.exports = {
 
 // This is adapted from https://github.com/normalize/mz
 // Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 const fs = __nccwpck_require__(7758)
 
 const api = [
@@ -1540,7 +1540,7 @@ module.exports = {
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const jsonFile = __nccwpck_require__(8970)
 
 jsonFile.outputJson = u(__nccwpck_require__(531))
@@ -1622,7 +1622,7 @@ module.exports = outputJson
 
 "use strict";
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const { makeDir: _makeDir, makeDirSync } = __nccwpck_require__(2751)
 const makeDir = u(_makeDir)
 
@@ -1684,7 +1684,7 @@ module.exports.makeDirSync = (dir, options) => {
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 
 // https://github.com/nodejs/node/issues/8987
 // https://github.com/libuv/libuv/pull/1088
@@ -1723,10 +1723,10 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const copySync = __nccwpck_require__(1135).copySync
-const removeSync = __nccwpck_require__(7357).removeSync
-const mkdirpSync = __nccwpck_require__(8605).mkdirpSync
+const path = __nccwpck_require__(1017)
+const copySync = (__nccwpck_require__(1135).copySync)
+const removeSync = (__nccwpck_require__(7357).removeSync)
+const mkdirpSync = (__nccwpck_require__(8605).mkdirpSync)
 const stat = __nccwpck_require__(3901)
 
 function moveSync (src, dest, opts) {
@@ -1784,7 +1784,7 @@ module.exports = moveSync
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 module.exports = {
   move: u(__nccwpck_require__(2231))
 }
@@ -1799,11 +1799,11 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const copy = __nccwpck_require__(1335).copy
-const remove = __nccwpck_require__(7357).remove
-const mkdirp = __nccwpck_require__(8605).mkdirp
-const pathExists = __nccwpck_require__(3835).pathExists
+const path = __nccwpck_require__(1017)
+const copy = (__nccwpck_require__(1335).copy)
+const remove = (__nccwpck_require__(7357).remove)
+const mkdirp = (__nccwpck_require__(8605).mkdirp)
+const pathExists = (__nccwpck_require__(3835).pathExists)
 const stat = __nccwpck_require__(3901)
 
 function move (src, dest, opts, cb) {
@@ -1879,11 +1879,11 @@ module.exports = move
 "use strict";
 
 
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
+const path = __nccwpck_require__(1017)
 const mkdir = __nccwpck_require__(8605)
-const pathExists = __nccwpck_require__(3835).pathExists
+const pathExists = (__nccwpck_require__(3835).pathExists)
 
 function outputFile (file, data, encoding, callback) {
   if (typeof encoding === 'function') {
@@ -1926,7 +1926,7 @@ module.exports = {
 
 "use strict";
 
-const u = __nccwpck_require__(9046).fromPromise
+const u = (__nccwpck_require__(9046).fromPromise)
 const fs = __nccwpck_require__(1176)
 
 function pathExists (path) {
@@ -1948,7 +1948,7 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const u = __nccwpck_require__(9046).fromCallback
+const u = (__nccwpck_require__(9046).fromCallback)
 const rimraf = __nccwpck_require__(8761)
 
 function remove (path, callback) {
@@ -1978,8 +1978,8 @@ module.exports = {
 
 
 const fs = __nccwpck_require__(7758)
-const path = __nccwpck_require__(5622)
-const assert = __nccwpck_require__(2357)
+const path = __nccwpck_require__(1017)
+const assert = __nccwpck_require__(9491)
 
 const isWindows = (process.platform === 'win32')
 
@@ -2288,8 +2288,8 @@ rimraf.sync = rimrafSync
 
 
 const fs = __nccwpck_require__(1176)
-const path = __nccwpck_require__(5622)
-const util = __nccwpck_require__(1669)
+const path = __nccwpck_require__(1017)
+const util = __nccwpck_require__(3837)
 
 function getStats (src, dest, opts) {
   const statFunc = opts.dereference
@@ -2511,12 +2511,12 @@ function clone (obj) {
 /***/ 7758:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var fs = __nccwpck_require__(5747)
+var fs = __nccwpck_require__(7147)
 var polyfills = __nccwpck_require__(263)
 var legacy = __nccwpck_require__(3086)
 var clone = __nccwpck_require__(7356)
 
-var util = __nccwpck_require__(1669)
+var util = __nccwpck_require__(3837)
 
 /* istanbul ignore next - node 0.x polyfill */
 var gracefulQueue
@@ -2597,7 +2597,7 @@ if (!fs[gracefulQueue]) {
   if (/\bgfs4\b/i.test(process.env.NODE_DEBUG || '')) {
     process.on('exit', function() {
       debug(fs[gracefulQueue])
-      __nccwpck_require__(2357).equal(fs[gracefulQueue].length, 0)
+      __nccwpck_require__(9491).equal(fs[gracefulQueue].length, 0)
     })
   }
 }
@@ -2891,7 +2891,7 @@ function retry () {
 /***/ 3086:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var Stream = __nccwpck_require__(2413).Stream
+var Stream = (__nccwpck_require__(2781).Stream)
 
 module.exports = legacy
 
@@ -3016,7 +3016,7 @@ function legacy (fs) {
 /***/ 263:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var constants = __nccwpck_require__(7619)
+var constants = __nccwpck_require__(2057)
 
 var origCwd = process.cwd
 var cwd = null
@@ -3373,7 +3373,7 @@ let _fs
 try {
   _fs = __nccwpck_require__(7758)
 } catch (_) {
-  _fs = __nccwpck_require__(5747)
+  _fs = __nccwpck_require__(7147)
 }
 const universalify = __nccwpck_require__(9046)
 const { stringify, stripBom } = __nccwpck_require__(5902)
@@ -3533,7 +3533,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Licensed under the MIT License.
 const core = __nccwpck_require__(2186);
 const lib_1 = __nccwpck_require__(2806);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 const fs = __nccwpck_require__(5630);
 core.startGroup('clone-solution:');
 const solutionName = core.getInput('solution-name', { required: true });
@@ -3845,7 +3845,7 @@ function createLegacyRunnerPacAuthenticator(pac) {
         });
     }
 }
-exports.default = createLegacyRunnerPacAuthenticator;
+exports["default"] = createLegacyRunnerPacAuthenticator;
 
 //# sourceMappingURL=createLegacyRunnerPacAuthenticator.js.map
 
@@ -3862,7 +3862,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -3887,11 +3887,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.ExeRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const child_process_1 = __nccwpck_require__(3129);
-const os = __nccwpck_require__(2087);
+const child_process_1 = __nccwpck_require__(2081);
+const os = __nccwpck_require__(2037);
 const getExePath_1 = __nccwpck_require__(309);
 const runnerParameters_1 = __nccwpck_require__(7727);
-const process = __nccwpck_require__(1765);
+const process = __nccwpck_require__(7282);
 class ExeRunner {
     constructor(_workingDir, logger, exeName, exeRelativePath) {
         this._workingDir = _workingDir;
@@ -3976,7 +3976,7 @@ exports.RunnerError = RunnerError;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -3998,7 +3998,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -4041,7 +4041,7 @@ Object.defineProperty(exports, "getInputAsBool", ({ enumerable: true, get: funct
 Object.defineProperty(exports, "getWorkingDirectory", ({ enumerable: true, get: function () { return actionInput_1.getWorkingDirectory; } }));
 var exeRunner_1 = __nccwpck_require__(7021);
 Object.defineProperty(exports, "RunnerError", ({ enumerable: true, get: function () { return exeRunner_1.RunnerError; } }));
-var runnerFactory_1 = __nccwpck_require__(7147);
+var runnerFactory_1 = __nccwpck_require__(7597);
 Object.defineProperty(exports, "DefaultRunnerFactory", ({ enumerable: true, get: function () { return runnerFactory_1.DefaultRunnerFactory; } }));
 // TODO: delete exports once all actions are converted:
 var actionLogger_1 = __nccwpck_require__(3970);
@@ -4069,7 +4069,7 @@ exports.PacRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const exeRunner_1 = __nccwpck_require__(7021);
-const os = __nccwpck_require__(2087);
+const os = __nccwpck_require__(2037);
 const platform = os.platform();
 const programName = platform === "win32" ? 'pac.exe' : 'pac';
 const programPath = platform === "win32" ? ['pac', 'tools'] : ['pac_linux', 'tools'];
@@ -4085,7 +4085,7 @@ exports.PacRunner = PacRunner;
 
 /***/ }),
 
-/***/ 7147:
+/***/ 7597:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4126,12 +4126,12 @@ exports.DefaultRunnerFactory = new RealRunnerFactory();
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -4149,15 +4149,7 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-"use strict";
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 2357:
+/***/ 9491:
 /***/ ((module) => {
 
 "use strict";
@@ -4165,7 +4157,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 "use strict";
@@ -4173,7 +4165,7 @@ module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 7619:
+/***/ 2057:
 /***/ ((module) => {
 
 "use strict";
@@ -4181,7 +4173,7 @@ module.exports = require("constants");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 "use strict";
@@ -4189,7 +4181,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 "use strict";
@@ -4197,7 +4189,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 "use strict";
@@ -4205,7 +4197,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 "use strict";
@@ -4213,7 +4205,7 @@ module.exports = require("process");
 
 /***/ }),
 
-/***/ 2413:
+/***/ 2781:
 /***/ ((module) => {
 
 "use strict";
@@ -4221,11 +4213,19 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 1669:
+/***/ 3837:
 /***/ ((module) => {
 
 "use strict";
 module.exports = require("util");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+"use strict";
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/copy-environment/index.js
+++ b/dist/actions/copy-environment/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5965,7 +5965,7 @@ const runnerParameters_1 = __nccwpck_require__(7727);
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         const taskParser = new YamlParser_1.YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "copy-environment");
+        const parameterMap = taskParser.getHostParameterEntries('copy-environment');
         core.startGroup('copy-environment:');
         yield actions_1.copyEnvironment({
             credentials: getCredentials_1.default(),
@@ -6049,7 +6049,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6072,7 +6072,7 @@ function isClientCredentialsValid(clientCredentials) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6094,7 +6094,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6131,15 +6131,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6157,6 +6160,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6171,12 +6193,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6194,45 +6216,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/create-environment/index.js
+++ b/dist/actions/create-environment/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5965,7 +5965,7 @@ const runnerParameters_1 = __nccwpck_require__(7727);
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         const taskParser = new YamlParser_1.YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "create-environment");
+        const parameterMap = taskParser.getHostParameterEntries('create-environment');
         core.startGroup('create-environment:');
         const result = yield actions_1.createEnvironment({
             credentials: getCredentials_1.default(),
@@ -6056,7 +6056,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6079,7 +6079,7 @@ function isClientCredentialsValid(clientCredentials) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6101,7 +6101,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6138,15 +6138,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6164,6 +6167,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6178,12 +6200,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6201,45 +6223,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/delete-environment/index.js
+++ b/dist/actions/delete-environment/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(87));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const os = __importStar(__nccwpck_require__(37));
+const path = __importStar(__nccwpck_require__(17));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
+const fs = __importStar(__nccwpck_require__(147));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -810,7 +810,7 @@ function createLegacyRunnerPacAuthenticator(pac) {
         });
     }
 }
-exports.default = createLegacyRunnerPacAuthenticator;
+exports["default"] = createLegacyRunnerPacAuthenticator;
 
 //# sourceMappingURL=createLegacyRunnerPacAuthenticator.js.map
 
@@ -826,7 +826,7 @@ const core_1 = __nccwpck_require__(186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -850,11 +850,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.ExeRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const child_process_1 = __nccwpck_require__(129);
-const os = __nccwpck_require__(87);
+const child_process_1 = __nccwpck_require__(81);
+const os = __nccwpck_require__(37);
 const getExePath_1 = __nccwpck_require__(309);
 const runnerParameters_1 = __nccwpck_require__(727);
-const process = __nccwpck_require__(765);
+const process = __nccwpck_require__(282);
 class ExeRunner {
     constructor(_workingDir, logger, exeName, exeRelativePath) {
         this._workingDir = _workingDir;
@@ -938,7 +938,7 @@ exports.RunnerError = RunnerError;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(622);
+const path_1 = __nccwpck_require__(17);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -960,7 +960,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -1001,7 +1001,7 @@ Object.defineProperty(exports, "getInputAsBool", ({ enumerable: true, get: funct
 Object.defineProperty(exports, "getWorkingDirectory", ({ enumerable: true, get: function () { return actionInput_1.getWorkingDirectory; } }));
 var exeRunner_1 = __nccwpck_require__(21);
 Object.defineProperty(exports, "RunnerError", ({ enumerable: true, get: function () { return exeRunner_1.RunnerError; } }));
-var runnerFactory_1 = __nccwpck_require__(147);
+var runnerFactory_1 = __nccwpck_require__(597);
 Object.defineProperty(exports, "DefaultRunnerFactory", ({ enumerable: true, get: function () { return runnerFactory_1.DefaultRunnerFactory; } }));
 // TODO: delete exports once all actions are converted:
 var actionLogger_1 = __nccwpck_require__(970);
@@ -1028,7 +1028,7 @@ exports.PacRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const exeRunner_1 = __nccwpck_require__(21);
-const os = __nccwpck_require__(87);
+const os = __nccwpck_require__(37);
 const platform = os.platform();
 const programName = platform === "win32" ? 'pac.exe' : 'pac';
 const programPath = platform === "win32" ? ['pac', 'tools'] : ['pac_linux', 'tools'];
@@ -1044,7 +1044,7 @@ exports.PacRunner = PacRunner;
 
 /***/ }),
 
-/***/ 147:
+/***/ 597:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
@@ -1083,12 +1083,12 @@ exports.DefaultRunnerFactory = new RealRunnerFactory();
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(765);
+const process_1 = __nccwpck_require__(282);
 const actionLogger_1 = __nccwpck_require__(970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(598);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -1106,45 +1106,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 129:
+/***/ 81:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 747:
+/***/ 147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 87:
+/***/ 37:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 622:
+/***/ 17:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 765:
+/***/ 282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 598:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/delete-solution/index.js
+++ b/dist/actions/delete-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5964,7 +5964,7 @@ function main() {
         try {
             core.startGroup('delete-solution:');
             const taskParser = new YamlParser_1.YamlParser();
-            const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "delete-solution");
+            const parameterMap = taskParser.getHostParameterEntries('delete-solution');
             yield actions_1.deleteSolution({
                 credentials: getCredentials_1.default(),
                 environmentUrl: getEnvironmentUrl_1.default(),
@@ -6050,7 +6050,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6077,7 +6077,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6089,7 +6089,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6111,7 +6111,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6148,15 +6148,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6174,6 +6177,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6188,12 +6210,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6211,45 +6233,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/deploy-package/index.js
+++ b/dist/actions/deploy-package/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5964,7 +5964,7 @@ function main() {
         try {
             core.startGroup('deploy-package:');
             const taskParser = new YamlParser_1.YamlParser();
-            const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "deploy-package");
+            const parameterMap = taskParser.getHostParameterEntries('deploy-package');
             yield actions_1.deployPackage({
                 credentials: getCredentials_1.default(),
                 environmentUrl: getEnvironmentUrl_1.default(),
@@ -6050,7 +6050,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6077,7 +6077,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6089,7 +6089,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6111,7 +6111,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6148,15 +6148,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6174,6 +6177,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6188,12 +6210,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6211,45 +6233,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/download-paportal/index.js
+++ b/dist/actions/download-paportal/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5955,7 +5955,7 @@ const getEnvironmentUrl_1 = __nccwpck_require__(699);
 const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "download-paportal");
+    const parameterMap = taskParser.getHostParameterEntries('download-paportal');
     yield actions_1.downloadPaportal({
         credentials: getCredentials_1.default(),
         environmentUrl: getEnvironmentUrl_1.default(),
@@ -6038,7 +6038,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6065,7 +6065,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6077,7 +6077,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6099,7 +6099,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6136,15 +6136,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6162,6 +6165,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6176,12 +6198,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6199,45 +6221,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/export-solution/index.js
+++ b/dist/actions/export-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5955,7 +5955,7 @@ const getEnvironmentUrl_1 = __nccwpck_require__(699);
 const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "export-solution");
+    const parameterMap = taskParser.getHostParameterEntries('export-solution');
     const actionsHost = new ActionsHost_1.ActionsHost();
     const workingDir = actionsHost.getInput({ name: "working-directory", required: false });
     if (workingDir) {
@@ -6059,7 +6059,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6086,7 +6086,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6098,7 +6098,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6120,7 +6120,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6157,15 +6157,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6183,6 +6186,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6197,12 +6219,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6220,45 +6242,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/import-solution/index.js
+++ b/dist/actions/import-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5955,7 +5955,7 @@ const getEnvironmentUrl_1 = __nccwpck_require__(699);
 const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "import-solution");
+    const parameterMap = taskParser.getHostParameterEntries('import-solution');
     const actionsHost = new ActionsHost_1.ActionsHost();
     const workingDir = actionsHost.getInput({ name: "working-directory", required: false });
     if (workingDir) {
@@ -6053,7 +6053,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6080,7 +6080,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6092,7 +6092,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6114,7 +6114,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6151,15 +6151,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6177,6 +6180,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6191,12 +6213,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6214,45 +6236,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/pack-solution/index.js
+++ b/dist/actions/pack-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5954,7 +5954,7 @@ const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     core.startGroup('pack-solution:');
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "pack-solution");
+    const parameterMap = taskParser.getHostParameterEntries('pack-solution');
     yield actions_1.packSolution({
         solutionZipFile: parameterMap['solution-file'],
         sourceFolder: parameterMap['solution-folder'],
@@ -6012,7 +6012,7 @@ exports.ActionLogger = ActionLogger;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6034,7 +6034,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6071,15 +6071,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6097,6 +6100,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6111,12 +6133,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6134,45 +6156,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/publish-solution/index.js
+++ b/dist/actions/publish-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(87));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const os = __importStar(__nccwpck_require__(37));
+const path = __importStar(__nccwpck_require__(17));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
+const fs = __importStar(__nccwpck_require__(147));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(129);
-const process_1 = __nccwpck_require__(316);
-const os_1 = __nccwpck_require__(87);
-const process = __nccwpck_require__(316);
+const child_process_1 = __nccwpck_require__(81);
+const process_1 = __nccwpck_require__(282);
+const os_1 = __nccwpck_require__(37);
+const process = __nccwpck_require__(282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
-const os = __nccwpck_require__(87);
+const path = __nccwpck_require__(17);
+const os = __nccwpck_require__(37);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(87);
-const path_1 = __nccwpck_require__(622);
+const os_1 = __nccwpck_require__(37);
+const path_1 = __nccwpck_require__(17);
 const CommandRunner_1 = __nccwpck_require__(892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -1962,7 +1962,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -1989,7 +1989,7 @@ const core_1 = __nccwpck_require__(186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -2001,7 +2001,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(622);
+const path_1 = __nccwpck_require__(17);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -2023,7 +2023,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -2036,12 +2036,12 @@ exports.default = getExePath;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(316);
+const process_1 = __nccwpck_require__(282);
 const actionLogger_1 = __nccwpck_require__(970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(314);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -2059,45 +2059,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 129:
+/***/ 81:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 747:
+/***/ 147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 87:
+/***/ 37:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 622:
+/***/ 17:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 316:
+/***/ 282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 314:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/reset-environment/index.js
+++ b/dist/actions/reset-environment/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(87));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const os = __importStar(__nccwpck_require__(37));
+const path = __importStar(__nccwpck_require__(17));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
+const fs = __importStar(__nccwpck_require__(147));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -800,7 +800,7 @@ function createLegacyRunnerPacAuthenticator(pac) {
         });
     }
 }
-exports.default = createLegacyRunnerPacAuthenticator;
+exports["default"] = createLegacyRunnerPacAuthenticator;
 
 //# sourceMappingURL=createLegacyRunnerPacAuthenticator.js.map
 
@@ -816,7 +816,7 @@ const core_1 = __nccwpck_require__(186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -840,11 +840,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.ExeRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const child_process_1 = __nccwpck_require__(129);
-const os = __nccwpck_require__(87);
+const child_process_1 = __nccwpck_require__(81);
+const os = __nccwpck_require__(37);
 const getExePath_1 = __nccwpck_require__(309);
 const runnerParameters_1 = __nccwpck_require__(727);
-const process = __nccwpck_require__(765);
+const process = __nccwpck_require__(282);
 class ExeRunner {
     constructor(_workingDir, logger, exeName, exeRelativePath) {
         this._workingDir = _workingDir;
@@ -928,7 +928,7 @@ exports.RunnerError = RunnerError;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(622);
+const path_1 = __nccwpck_require__(17);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -950,7 +950,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -991,7 +991,7 @@ Object.defineProperty(exports, "getInputAsBool", ({ enumerable: true, get: funct
 Object.defineProperty(exports, "getWorkingDirectory", ({ enumerable: true, get: function () { return actionInput_1.getWorkingDirectory; } }));
 var exeRunner_1 = __nccwpck_require__(21);
 Object.defineProperty(exports, "RunnerError", ({ enumerable: true, get: function () { return exeRunner_1.RunnerError; } }));
-var runnerFactory_1 = __nccwpck_require__(147);
+var runnerFactory_1 = __nccwpck_require__(597);
 Object.defineProperty(exports, "DefaultRunnerFactory", ({ enumerable: true, get: function () { return runnerFactory_1.DefaultRunnerFactory; } }));
 // TODO: delete exports once all actions are converted:
 var actionLogger_1 = __nccwpck_require__(970);
@@ -1018,7 +1018,7 @@ exports.PacRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const exeRunner_1 = __nccwpck_require__(21);
-const os = __nccwpck_require__(87);
+const os = __nccwpck_require__(37);
 const platform = os.platform();
 const programName = platform === "win32" ? 'pac.exe' : 'pac';
 const programPath = platform === "win32" ? ['pac', 'tools'] : ['pac_linux', 'tools'];
@@ -1034,7 +1034,7 @@ exports.PacRunner = PacRunner;
 
 /***/ }),
 
-/***/ 147:
+/***/ 597:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
@@ -1073,12 +1073,12 @@ exports.DefaultRunnerFactory = new RealRunnerFactory();
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(765);
+const process_1 = __nccwpck_require__(282);
 const actionLogger_1 = __nccwpck_require__(970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(598);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -1096,45 +1096,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 129:
+/***/ 81:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 747:
+/***/ 147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 87:
+/***/ 37:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 622:
+/***/ 17:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 765:
+/***/ 282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 598:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/restore-environment/index.js
+++ b/dist/actions/restore-environment/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(87));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const os = __importStar(__nccwpck_require__(37));
+const path = __importStar(__nccwpck_require__(17));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
+const fs = __importStar(__nccwpck_require__(147));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -802,7 +802,7 @@ function createLegacyRunnerPacAuthenticator(pac) {
         });
     }
 }
-exports.default = createLegacyRunnerPacAuthenticator;
+exports["default"] = createLegacyRunnerPacAuthenticator;
 
 //# sourceMappingURL=createLegacyRunnerPacAuthenticator.js.map
 
@@ -818,7 +818,7 @@ const core_1 = __nccwpck_require__(186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -842,11 +842,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.ExeRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const child_process_1 = __nccwpck_require__(129);
-const os = __nccwpck_require__(87);
+const child_process_1 = __nccwpck_require__(81);
+const os = __nccwpck_require__(37);
 const getExePath_1 = __nccwpck_require__(309);
 const runnerParameters_1 = __nccwpck_require__(727);
-const process = __nccwpck_require__(765);
+const process = __nccwpck_require__(282);
 class ExeRunner {
     constructor(_workingDir, logger, exeName, exeRelativePath) {
         this._workingDir = _workingDir;
@@ -930,7 +930,7 @@ exports.RunnerError = RunnerError;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(622);
+const path_1 = __nccwpck_require__(17);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -952,7 +952,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -993,7 +993,7 @@ Object.defineProperty(exports, "getInputAsBool", ({ enumerable: true, get: funct
 Object.defineProperty(exports, "getWorkingDirectory", ({ enumerable: true, get: function () { return actionInput_1.getWorkingDirectory; } }));
 var exeRunner_1 = __nccwpck_require__(21);
 Object.defineProperty(exports, "RunnerError", ({ enumerable: true, get: function () { return exeRunner_1.RunnerError; } }));
-var runnerFactory_1 = __nccwpck_require__(147);
+var runnerFactory_1 = __nccwpck_require__(597);
 Object.defineProperty(exports, "DefaultRunnerFactory", ({ enumerable: true, get: function () { return runnerFactory_1.DefaultRunnerFactory; } }));
 // TODO: delete exports once all actions are converted:
 var actionLogger_1 = __nccwpck_require__(970);
@@ -1020,7 +1020,7 @@ exports.PacRunner = void 0;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 const exeRunner_1 = __nccwpck_require__(21);
-const os = __nccwpck_require__(87);
+const os = __nccwpck_require__(37);
 const platform = os.platform();
 const programName = platform === "win32" ? 'pac.exe' : 'pac';
 const programPath = platform === "win32" ? ['pac', 'tools'] : ['pac_linux', 'tools'];
@@ -1036,7 +1036,7 @@ exports.PacRunner = PacRunner;
 
 /***/ }),
 
-/***/ 147:
+/***/ 597:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
@@ -1075,12 +1075,12 @@ exports.DefaultRunnerFactory = new RealRunnerFactory();
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(765);
+const process_1 = __nccwpck_require__(282);
 const actionLogger_1 = __nccwpck_require__(970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(598);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -1098,45 +1098,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 129:
+/***/ 81:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 747:
+/***/ 147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 87:
+/***/ 37:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 622:
+/***/ 17:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 765:
+/***/ 282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 598:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/unpack-solution/index.js
+++ b/dist/actions/unpack-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5954,7 +5954,7 @@ const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     core.startGroup('unpack-solution:');
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "unpack-solution");
+    const parameterMap = taskParser.getHostParameterEntries('unpack-solution');
     yield actions_1.unpackSolution({
         solutionZipFile: parameterMap['solution-file'],
         sourceFolder: parameterMap['solution-folder'],
@@ -6013,7 +6013,7 @@ exports.ActionLogger = ActionLogger;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6035,7 +6035,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6072,15 +6072,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6098,6 +6101,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6112,12 +6134,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6135,45 +6157,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/update-solution-version/index.js
+++ b/dist/actions/update-solution-version/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5964,7 +5964,7 @@ function main() {
         try {
             core.startGroup('update-solution-version:');
             const taskParser = new YamlParser_1.YamlParser();
-            const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "update-solution-version");
+            const parameterMap = taskParser.getHostParameterEntries('update-solution-version');
             yield actions_1.updateVersionSolution({
                 credentials: getCredentials_1.default(),
                 environmentUrl: getEnvironmentUrl_1.default(),
@@ -6052,7 +6052,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6079,7 +6079,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6091,7 +6091,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6113,7 +6113,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6150,15 +6150,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6176,6 +6179,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6190,12 +6212,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6213,45 +6235,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/upgrade-solution/index.js
+++ b/dist/actions/upgrade-solution/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5964,7 +5964,7 @@ function main() {
         try {
             core.startGroup('upgrade-solution:');
             const taskParser = new YamlParser_1.YamlParser();
-            const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "upgrade-solution");
+            const parameterMap = taskParser.getHostParameterEntries('upgrade-solution');
             yield actions_1.upgradeSolution({
                 credentials: getCredentials_1.default(),
                 environmentUrl: getEnvironmentUrl_1.default(),
@@ -6052,7 +6052,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6079,7 +6079,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6091,7 +6091,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6113,7 +6113,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6150,15 +6150,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6176,6 +6179,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6190,12 +6212,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6213,45 +6235,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/upload-paportal/index.js
+++ b/dist/actions/upload-paportal/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2087));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
-const os = __importStar(__nccwpck_require__(2087));
-const path = __importStar(__nccwpck_require__(5622));
+const os = __importStar(__nccwpck_require__(2037));
+const path = __importStar(__nccwpck_require__(1017));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(5747));
-const os = __importStar(__nccwpck_require__(2087));
+const fs = __importStar(__nccwpck_require__(7147));
+const os = __importStar(__nccwpck_require__(2037));
 const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(3129);
-const process_1 = __nccwpck_require__(1765);
-const os_1 = __nccwpck_require__(2087);
-const process = __nccwpck_require__(1765);
+const child_process_1 = __nccwpck_require__(2081);
+const process_1 = __nccwpck_require__(7282);
+const os_1 = __nccwpck_require__(2037);
+const process = __nccwpck_require__(7282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
-const os = __nccwpck_require__(2087);
+const path = __nccwpck_require__(1017);
+const os = __nccwpck_require__(2037);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(9988);
 const createPacRunner_1 = __nccwpck_require__(2226);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(2087);
-const path_1 = __nccwpck_require__(5622);
+const os_1 = __nccwpck_require__(2037);
+const path_1 = __nccwpck_require__(1017);
 const CommandRunner_1 = __nccwpck_require__(5892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -4894,7 +4894,7 @@ module.exports = __nccwpck_require__(1035);
 
 
 
-module.exports = __nccwpck_require__(2011).extend({
+module.exports = (__nccwpck_require__(2011).extend)({
   implicit: [
     __nccwpck_require__(9212),
     __nccwpck_require__(6104)
@@ -4948,7 +4948,7 @@ module.exports = new Schema({
 
 
 
-module.exports = __nccwpck_require__(8562).extend({
+module.exports = (__nccwpck_require__(8562).extend)({
   implicit: [
     __nccwpck_require__(721),
     __nccwpck_require__(4993),
@@ -5955,7 +5955,7 @@ const getEnvironmentUrl_1 = __nccwpck_require__(699);
 const runnerParameters_1 = __nccwpck_require__(7727);
 (() => __awaiter(void 0, void 0, void 0, function* () {
     const taskParser = new YamlParser_1.YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters_1.runnerParameters.workingDir, "upload-paportal");
+    const parameterMap = taskParser.getHostParameterEntries('upload-paportal');
     yield actions_1.uploadPaportal({
         credentials: getCredentials_1.default(),
         environmentUrl: getEnvironmentUrl_1.default(),
@@ -6038,7 +6038,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -6065,7 +6065,7 @@ const core_1 = __nccwpck_require__(2186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -6077,7 +6077,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(5622);
+const path_1 = __nccwpck_require__(1017);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -6099,7 +6099,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -6136,15 +6136,18 @@ exports.ActionsHost = ActionsHost;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.YamlParser = void 0;
-const fs = __nccwpck_require__(5747);
+const fs = __nccwpck_require__(7147);
 const yaml = __nccwpck_require__(1917);
-const path = __nccwpck_require__(5622);
+const path = __nccwpck_require__(1017);
 class YamlParser {
-    getHostParameterEntries(workingDir, actionFolder) {
+    constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+    getHostParameterEntries(actionFolder) {
         var _a;
         const parameterMap = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents);
@@ -6162,6 +6165,25 @@ class YamlParser {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
     }
+    findArchiveRoot(startSearchFolder) {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8'));
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
+    }
 }
 exports.YamlParser = YamlParser;
 
@@ -6176,12 +6198,12 @@ exports.YamlParser = YamlParser;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(1765);
+const process_1 = __nccwpck_require__(7282);
 const actionLogger_1 = __nccwpck_require__(3970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(4147);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -6199,45 +6221,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 3129:
+/***/ 2081:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 5747:
+/***/ 7147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 2087:
+/***/ 2037:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 5622:
+/***/ 1017:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 1765:
+/***/ 7282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 4147:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/dist/actions/who-am-i/index.js
+++ b/dist/actions/who-am-i/index.js
@@ -27,7 +27,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(87));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 /**
  * Commands
@@ -137,8 +137,8 @@ exports.getState = exports.saveState = exports.group = exports.endGroup = export
 const command_1 = __nccwpck_require__(351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const os = __importStar(__nccwpck_require__(37));
+const path = __importStar(__nccwpck_require__(17));
 /**
  * The code to exit an action
  */
@@ -428,8 +428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
+const fs = __importStar(__nccwpck_require__(147));
+const os = __importStar(__nccwpck_require__(37));
 const utils_1 = __nccwpck_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
@@ -489,10 +489,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RunnerError = exports.createCommandRunner = void 0;
-const child_process_1 = __nccwpck_require__(129);
-const process_1 = __nccwpck_require__(316);
-const os_1 = __nccwpck_require__(87);
-const process = __nccwpck_require__(316);
+const child_process_1 = __nccwpck_require__(81);
+const process_1 = __nccwpck_require__(282);
+const os_1 = __nccwpck_require__(37);
+const process = __nccwpck_require__(282);
 function createCommandRunner(workingDir, commandPath, logger, options, agent) {
     return function run(...args) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -618,7 +618,7 @@ exports.checkSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function checkSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -987,8 +987,8 @@ exports.deployPackage = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
-const os = __nccwpck_require__(87);
+const path = __nccwpck_require__(17);
+const os = __nccwpck_require__(37);
 function deployPackage(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1094,7 +1094,7 @@ exports.exportSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function exportSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1188,7 +1188,7 @@ exports.importSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const authenticate_1 = __nccwpck_require__(192);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function importSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1293,7 +1293,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.packSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function packSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1510,7 +1510,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.unpackSolution = void 0;
 const InputValidator_1 = __nccwpck_require__(988);
 const createPacRunner_1 = __nccwpck_require__(226);
-const path = __nccwpck_require__(622);
+const path = __nccwpck_require__(17);
 function unpackSolution(parameters, runnerParameters, host) {
     return __awaiter(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
@@ -1832,15 +1832,15 @@ function addUsernamePassword(parameters) {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os_1 = __nccwpck_require__(87);
-const path_1 = __nccwpck_require__(622);
+const os_1 = __nccwpck_require__(37);
+const path_1 = __nccwpck_require__(17);
 const CommandRunner_1 = __nccwpck_require__(892);
 function createPacRunner({ workingDir, runnersDir, logger, agent }) {
     return CommandRunner_1.createCommandRunner(workingDir, os_1.platform() === "win32"
         ? path_1.resolve(runnersDir, "pac", "tools", "pac.exe")
         : path_1.resolve(runnersDir, "pac_linux", "tools", "pac"), logger, undefined, agent);
 }
-exports.default = createPacRunner;
+exports["default"] = createPacRunner;
 
 //# sourceMappingURL=createPacRunner.js.map
 
@@ -1950,7 +1950,7 @@ function getCredentials() {
     }
     throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
 }
-exports.default = getCredentials;
+exports["default"] = getCredentials;
 function getInput(name) {
     return core_1.getInput(name, { required: false });
 }
@@ -1977,7 +1977,7 @@ const core_1 = __nccwpck_require__(186);
 function getEnvironmentUrl() {
     return core_1.getInput("environment-url", { required: false });
 }
-exports.default = getEnvironmentUrl;
+exports["default"] = getEnvironmentUrl;
 
 //# sourceMappingURL=getEnvironmentUrl.js.map
 
@@ -1989,7 +1989,7 @@ exports.default = getEnvironmentUrl;
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __nccwpck_require__(622);
+const path_1 = __nccwpck_require__(17);
 function getExePath(...relativePath) {
     // in mocha, __dirname resolves to the src folder of the .ts file,
     // but when running the .js file directly, e.g. from the /dist folder, it will be from that folder
@@ -2011,7 +2011,7 @@ function getExePath(...relativePath) {
     }
     return path_1.resolve(outDirRoot, ...relativePath);
 }
-exports.default = getExePath;
+exports["default"] = getExePath;
 
 //# sourceMappingURL=getExePath.js.map
 
@@ -2024,12 +2024,12 @@ exports.default = getExePath;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getAutomationAgent = exports.runnerParameters = void 0;
-const process_1 = __nccwpck_require__(316);
+const process_1 = __nccwpck_require__(282);
 const actionLogger_1 = __nccwpck_require__(970);
 const getExePath_1 = __nccwpck_require__(309);
 function getAutomationAgent() {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const jsonPackage = __nccwpck_require__(306);
+    const jsonPackage = __nccwpck_require__(314);
     const productName = jsonPackage.name.split("/")[1];
     return productName + "/" + jsonPackage.version;
 }
@@ -2047,45 +2047,45 @@ exports.runnerParameters = runnerParameters;
 
 /***/ }),
 
-/***/ 306:
-/***/ ((module) => {
-
-module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.31.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
-
-/***/ }),
-
-/***/ 129:
+/***/ 81:
 /***/ ((module) => {
 
 module.exports = require("child_process");
 
 /***/ }),
 
-/***/ 747:
+/***/ 147:
 /***/ ((module) => {
 
 module.exports = require("fs");
 
 /***/ }),
 
-/***/ 87:
+/***/ 37:
 /***/ ((module) => {
 
 module.exports = require("os");
 
 /***/ }),
 
-/***/ 622:
+/***/ 17:
 /***/ ((module) => {
 
 module.exports = require("path");
 
 /***/ }),
 
-/***/ 316:
+/***/ 282:
 /***/ ((module) => {
 
 module.exports = require("process");
+
+/***/ }),
+
+/***/ 314:
+/***/ ((module) => {
+
+module.exports = JSON.parse('{"name":"@microsoft/powerplatform-actions","version":"0.1.0","description":"Github Action for Power Platform","main":"index.js","scripts":{"clean":"scorch","build":"node node_modules/gulp/bin/gulp.js","test":"node node_modules/gulp/bin/gulp.js test","ci":"node node_modules/gulp/bin/gulp.js ci","update-dist":"node node_modules/gulp/bin/gulp.js updateDist"},"author":"PowerApps-ISV-Tools","license":"MIT","repository":{"type":"git","url":"https://github.com/microsoft/powerplatform-actions.git"},"devDependencies":{"@types/async":"^3.2.7","@types/chai":"^4.2.20","@types/fancy-log":"^1.3.1","@types/fs-extra":"^9.0.12","@types/glob":"^7.1.4","@types/js-yaml":"^4.0.3","@types/mocha":"^8.2.3","@types/node":"^14.14.35","@types/sinon":"^9.0.11","@types/sinon-chai":"^3.2.5","@types/uuid":"^8.3.0","@types/yargs":"^17.0.2","@typescript-eslint/eslint-plugin":"^4.28.2","@typescript-eslint/parser":"^4.28.2","@vercel/ncc":"^0.33.1","async":"^3.2.0","chai":"^4.3.4","dotenv":"^8.2.0","eslint":"^7.30.0","fancy-log":"^1.3.3","glob":"^7.1.7","gulp":"^4.0.2","gulp-eslint":"^6.0.0","gulp-mocha":"^8.0.0","gulp-sourcemaps":"^3.0.0","gulp-typescript":"^6.0.0-alpha.1","mocha":"^9.0.2","node-fetch":"^2.6.1","ps-list":"^7.2.0","rewiremock":"^3.14.3","sinon":"^9.2.4","sinon-chai":"^3.5.0","ts-node":"^10.0.0","ts-sinon":"^2.0.1","typescript":"^4.3.5","unzip-stream":"^0.3.0","winston":"^3.3.3","yargs":"^17.0.1"},"dependencies":{"@actions/artifact":"^0.5.2","@actions/core":"^1.4.0","@microsoft/powerplatform-cli-wrapper":"^0.1.36","date-fns":"^2.22.1","fs-extra":"^10.0.0","js-yaml":"^4.1","uuid":"^8.3.2"}}');
 
 /***/ })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/yargs": "^17.0.2",
         "@typescript-eslint/eslint-plugin": "^4.28.2",
         "@typescript-eslint/parser": "^4.28.2",
-        "@vercel/ncc": "^0.31.1",
+        "@vercel/ncc": "^0.33.1",
         "async": "^3.2.0",
         "chai": "^4.3.4",
         "dotenv": "^8.2.0",
@@ -714,9 +714,9 @@
       "dev": true
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.1.tgz",
-      "integrity": "sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
+      "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -10486,9 +10486,9 @@
       "dev": true
     },
     "@vercel/ncc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.31.1.tgz",
-      "integrity": "sha512-g0FAxwdViI6UzsiVz5HssIHqjcPa1EHL6h+2dcJD893SoCJaGdqqgUF09xnMW6goWnnhbLvgiKlgJWrJa+7qYA==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
+      "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/yargs": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
-    "@vercel/ncc": "^0.31.1",
+    "@vercel/ncc": "^0.33.1",
     "async": "^3.2.0",
     "chai": "^4.3.4",
     "dotenv": "^8.2.0",

--- a/src/actions/backup-environment/index.ts
+++ b/src/actions/backup-environment/index.ts
@@ -19,7 +19,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 export async function main(): Promise<void> {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "backup-environment");
+    const parameterMap = taskParser.getHostParameterEntries('backup-environment');
 
     core.startGroup('backup-environment:');
 

--- a/src/actions/check-solution/index.ts
+++ b/src/actions/check-solution/index.ts
@@ -11,7 +11,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 (async () => {
     core.startGroup('check-solution:');
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "check-solution");
+    const parameterMap = taskParser.getHostParameterEntries('check-solution');
 
     await checkSolution({
         credentials: getCredentials(),

--- a/src/actions/copy-environment/index.ts
+++ b/src/actions/copy-environment/index.ts
@@ -19,7 +19,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 export async function main(): Promise<void> {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "copy-environment");
+    const parameterMap = taskParser.getHostParameterEntries('copy-environment');
 
     core.startGroup('copy-environment:');
     await copyEnvironment({

--- a/src/actions/create-environment/index.ts
+++ b/src/actions/create-environment/index.ts
@@ -19,7 +19,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 export async function main(): Promise<void> {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "create-environment");
+    const parameterMap = taskParser.getHostParameterEntries('create-environment');
 
     core.startGroup('create-environment:');
     const result = await createEnvironment({

--- a/src/actions/delete-solution/index.ts
+++ b/src/actions/delete-solution/index.ts
@@ -18,7 +18,7 @@ export async function main(): Promise<void> {
     try {
         core.startGroup('delete-solution:');
         const taskParser = new YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "delete-solution");
+        const parameterMap = taskParser.getHostParameterEntries('delete-solution');
 
         await deleteSolution({
             credentials: getCredentials(),

--- a/src/actions/deploy-package/index.ts
+++ b/src/actions/deploy-package/index.ts
@@ -18,7 +18,7 @@ export async function main(): Promise<void> {
     try {
         core.startGroup('deploy-package:');
         const taskParser = new YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "deploy-package");
+        const parameterMap = taskParser.getHostParameterEntries('deploy-package');
 
         await deployPackage({
             credentials: getCredentials(),

--- a/src/actions/download-paportal/index.ts
+++ b/src/actions/download-paportal/index.ts
@@ -10,7 +10,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 (async () => {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "download-paportal");
+    const parameterMap = taskParser.getHostParameterEntries('download-paportal');
 
     await downloadPaportal({
         credentials: getCredentials(),

--- a/src/actions/export-solution/index.ts
+++ b/src/actions/export-solution/index.ts
@@ -11,7 +11,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 (async () => {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "export-solution");
+    const parameterMap = taskParser.getHostParameterEntries('export-solution');
     const actionsHost = new ActionsHost();
     const workingDir = actionsHost.getInput({ name: "working-directory", required: false });
     if (workingDir) {

--- a/src/actions/import-solution/index.ts
+++ b/src/actions/import-solution/index.ts
@@ -11,7 +11,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 (async () => {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "import-solution");
+    const parameterMap = taskParser.getHostParameterEntries('import-solution');
     const actionsHost = new ActionsHost();
     const workingDir = actionsHost.getInput({ name: "working-directory", required: false });
     if (workingDir) {

--- a/src/actions/pack-solution/index.ts
+++ b/src/actions/pack-solution/index.ts
@@ -9,7 +9,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 (async () => {
     core.startGroup('pack-solution:');
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "pack-solution");
+    const parameterMap = taskParser.getHostParameterEntries('pack-solution');
 
     await packSolution({
       solutionZipFile: parameterMap['solution-file'],

--- a/src/actions/unpack-solution/index.ts
+++ b/src/actions/unpack-solution/index.ts
@@ -9,7 +9,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 (async () => {
     core.startGroup('unpack-solution:');
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "unpack-solution");
+    const parameterMap = taskParser.getHostParameterEntries('unpack-solution');
 
     await unpackSolution({
       solutionZipFile: parameterMap['solution-file'],

--- a/src/actions/update-solution-version/index.ts
+++ b/src/actions/update-solution-version/index.ts
@@ -18,7 +18,7 @@ export async function main(): Promise<void> {
     try {
         core.startGroup('update-solution-version:');
         const taskParser = new YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "update-solution-version");
+        const parameterMap = taskParser.getHostParameterEntries('update-solution-version');
 
         await updateVersionSolution({
             credentials: getCredentials(),

--- a/src/actions/upgrade-solution/index.ts
+++ b/src/actions/upgrade-solution/index.ts
@@ -18,7 +18,7 @@ export async function main(): Promise<void> {
     try {
         core.startGroup('upgrade-solution:');
         const taskParser = new YamlParser();
-        const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "upgrade-solution");
+        const parameterMap = taskParser.getHostParameterEntries('upgrade-solution');
 
         await upgradeSolution({
             credentials: getCredentials(),

--- a/src/actions/upload-paportal/index.ts
+++ b/src/actions/upload-paportal/index.ts
@@ -10,7 +10,7 @@ import { runnerParameters } from '../../lib/runnerParameters';
 
 (async () => {
     const taskParser = new YamlParser();
-    const parameterMap = taskParser.getHostParameterEntries(runnerParameters.workingDir, "upload-paportal");
+    const parameterMap = taskParser.getHostParameterEntries('upload-paportal');
 
     await uploadPaportal({
         credentials: getCredentials(),

--- a/src/lib/parser/YamlParser.ts
+++ b/src/lib/parser/YamlParser.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { HostParameterEntry } from "@microsoft/powerplatform-cli-wrapper/dist/host/IHostAbstractions";
 import fs = require('fs');
@@ -5,10 +7,16 @@ import yaml = require('js-yaml');
 import path = require("path");
 
 export class YamlParser {
-    public getHostParameterEntries(workingDir: string, actionFolder: string): Record<string, HostParameterEntry> {
+    private readonly _actionsArchiveRoot: string;
+
+    public constructor() {
+        this._actionsArchiveRoot = this.findArchiveRoot(__dirname);
+    }
+
+    public getHostParameterEntries(actionFolder: string): Record<string, HostParameterEntry> {
         const parameterMap: Record<string, HostParameterEntry> = {};
         try {
-            const file = path.join(workingDir, actionFolder, 'action.yml');
+            const file = path.resolve(this._actionsArchiveRoot, actionFolder, 'action.yml');
             console.log(`loading action yaml file: ${file}`);
             const fileContents = fs.readFileSync(file, 'utf8');
             const data = yaml.load(fileContents) as any;
@@ -24,5 +32,25 @@ export class YamlParser {
         } catch (e) {
             throw new Error(`Error parsing yaml file for ${actionFolder}: ${e}`);
         }
+    }
+
+    private findArchiveRoot(startSearchFolder: string): string {
+        // determine actions archive root, relative to this source file:
+        // walk up until the root action.yml is found, with pseudo/marketplace action named: 'powerplatform-actions'
+        let candidateDir = startSearchFolder;
+        const fsRoot = path.parse(candidateDir).root;
+        do {
+            const candidateActionYml = path.join(candidateDir, 'action.yml');
+            if (fs.existsSync(candidateActionYml)) {
+                const actionInfo = yaml.load(fs.readFileSync(candidateActionYml, 'utf-8')) as any;
+                if (actionInfo.name === 'powerplatform-actions') {
+                    return candidateDir;
+                }
+            }
+            else {
+                candidateDir = path.resolve(candidateDir, '..');
+            }
+        } while (candidateDir !== fsRoot);
+        throw new Error(`Cannot find pp-actions' archive root folder. Started search at: ${startSearchFolder}`);
     }
 }

--- a/src/test/data/action.yml
+++ b/src/test/data/action.yml
@@ -1,8 +1,0 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-name: 'test'
-inputs:
-  action-name:
-    required: true
-    default: "default"
-

--- a/src/test/yamlParser.test.ts
+++ b/src/test/yamlParser.test.ts
@@ -1,11 +1,16 @@
-import { assert } from "chai";
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { expect } from 'chai';
 import { YamlParser } from "../lib/parser/YamlParser";
 
 describe("Yaml Parser test", () => {
     it("calls parser", async () => {
-        const actionMap = {"action-name": { name: "action-name", required: true, defaultValue: "default"}};
         const parser = new YamlParser();
-        const parsedMap = parser.getHostParameterEntries(__dirname, "data");
-        assert.deepEqual(parsedMap, actionMap);
+        const actionInfo = parser.getHostParameterEntries('who-am-i');
+
+        const expectedInfo = {name: 'environment-url', required: false, defaultValue: undefined};
+        const info = actionInfo['environment-url'];
+        expect(info).to.be.not.null;
+        expect(info).to.be.deep.equal(expectedInfo);
     });
 });


### PR DESCRIPTION
Fixing a bad regression in 0.5.0: many actions failed early, since a new code part tries to validate the action input parameters with information from its action.yaml. That code stopped working once the action is run from a tarball:
Consuming repos load the referenced pp-actions from the tarball archive (powerplatform-actions-<tag>.tar.gz), which GH runners host in a folder outside of the source code repo.  

Fix is to determine the actions' root folder from the action's own location. This works for both local runs within our repo, but more importantly, when a consuming repo references our actions.

Addresses issue #158
