### PR TITLE
Deprecate usage of targetVersion parameter for export-solution and clone-solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Windows, macOS or Linux:
   ```Powershell
   [Environment]::SetEnvironmentVariable('AZ_DevOps_Read_PAT', '<yourPAT>', [EnvironmentVariableTarget]::User)
   ```
-  - Create a PAT in GitHub to read packages, and enable SSO for the microsoft organization.
+  - Create a [PAT in GitHub](https://github.com/settings/tokens) to read packages, and enable SSO for the microsoft organization.
   Then add it to your *~/.npmrc* file or use the `npm login --scope=@microsoft --registry=https://npm.pkg.github.com` command,
   as documented [here](https://docs.github.com/en/packages/guides/configuring-npm-for-use-with-github-packages#authenticating-with-a-personal-access-token).
   This will only be needed until the `@microsoft/powerplatform-cli-wrapper` repo is made public.

--- a/backup-environment/action.yml
+++ b/backup-environment/action.yml
@@ -16,8 +16,9 @@ inputs:
     required: true
 
   notes:
-    description: 'DEPRECATED: **ignored** Additional notes for this backup.'
+    description: 'DEPRECATED: Additional notes for this backup.'
     required: false
+    deprecationMessage: This property is deprecated and will be ignored.
 
   user-name:
     description: 'Power Platform user name to authenticate with, e.g. myname@my-org.onmicrosoft.com. Setting this input makes user-name and password required; specifying alternate "app-id" credential set of inputs will result in an error.'

--- a/clone-solution/action.yml
+++ b/clone-solution/action.yml
@@ -37,8 +37,9 @@ inputs:
     required: true
 
   solution-version:
-    description: 'Version of solution to clone'
+    description: 'DEPRECATED: Version of solution to clone'
     required: false
+    deprecationMessage: This property is deprecated and will be ignored.
 
   target-folder:
     description: 'Target folder to place the extracted solution into'

--- a/delete-environment/action.yml
+++ b/delete-environment/action.yml
@@ -8,8 +8,9 @@ inputs:
     required: false
 
   environment-id:
-    description: 'ID of Power Platform environment to delete(deprecated). Please use "environment" action property instead.'
+    description: 'DEPRECATED: ID of Power Platform environment to delete.'
     required: false
+    deprecationMessage: Please use the `environment` property instead.
 
   environment:
     description: 'URL or Id of Power Platform environment to delete.'

--- a/export-solution/action.yml
+++ b/export-solution/action.yml
@@ -32,8 +32,9 @@ inputs:
     required: true
 
   solution-version:
-    description: 'Version of solution to export'
+    description: 'DEPRECATED: Version of solution to export'
     required: false
+    deprecationMessage: This property is deprecated and will be ignored.
 
   solution-output-file:
     description: 'Path/filename where to place the exported solution zip file. Can be absolute or relative to working-directory'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/artifact": "^0.5.2",
         "@actions/core": "^1.4.0",
-        "@microsoft/powerplatform-cli-wrapper": "0.1.50",
+        "@microsoft/powerplatform-cli-wrapper": "0.1.51",
         "date-fns": "^2.22.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1",
@@ -373,9 +373,9 @@
       "dev": true
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.50",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.50/b0966750dbfe6ff4a85e69af07cc6d62b95a305ea98e386845b6d21fa1f98c98",
-      "integrity": "sha512-r2l/L1bwgtW1Piva5ksrktwEZzase5QhiUF0Inz1s5RDBGKwpPc5qDhhEShl6XwiZMiNvrZgy8euHvdUWC93/A==",
+      "version": "0.1.51",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.51/347dbe9c45aa5a9c3cfae431420290fcf9721cd6d1158b0fc28cf9adae04d5ce",
+      "integrity": "sha512-7E3dYRBpiTz3DSHse9F9s0guYkN3g89t0CjWyVH3JwbQ8L4djGuo+CfyhwxkU5SerAC8L/eWGHMz80Z+hNDVoA==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10698,9 +10698,9 @@
       "dev": true
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.50",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.50/b0966750dbfe6ff4a85e69af07cc6d62b95a305ea98e386845b6d21fa1f98c98",
-      "integrity": "sha512-r2l/L1bwgtW1Piva5ksrktwEZzase5QhiUF0Inz1s5RDBGKwpPc5qDhhEShl6XwiZMiNvrZgy8euHvdUWC93/A=="
+      "version": "0.1.51",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.51/347dbe9c45aa5a9c3cfae431420290fcf9721cd6d1158b0fc28cf9adae04d5ce",
+      "integrity": "sha512-7E3dYRBpiTz3DSHse9F9s0guYkN3g89t0CjWyVH3JwbQ8L4djGuo+CfyhwxkU5SerAC8L/eWGHMz80Z+hNDVoA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@actions/artifact": "^0.5.2",
     "@actions/core": "^1.4.0",
-    "@microsoft/powerplatform-cli-wrapper": "0.1.50",
+    "@microsoft/powerplatform-cli-wrapper": "0.1.51",
     "date-fns": "^2.22.1",
     "fs-extra": "^10.0.0",
     "js-yaml": "^4.1",

--- a/src/actions/clone-solution/actionLaunch.ts
+++ b/src/actions/clone-solution/actionLaunch.ts
@@ -13,7 +13,6 @@ process.env['INPUT_TENANT-ID'] = process.env['PA_BT_ORG_SPN_TENANT_ID'] ?? '3041
 const password = process.env['PA_BT_ORG_PASSWORD'] ?? '';
 process.env['INPUT_PASSWORD-SECRET'] = password;
 process.env['INPUT_SOLUTION-NAME'] = 'emptySolution';
-// process.env['INPUT_SOLUTION-VERSION'] = '1.42.0';
 process.env['INPUT_WORKING-DIRECTORY'] = path.resolve(__dirname, '..', '..', '..', 'out', 'cloned');
 // process.env['INPUT_TARGET-FOLDER'] = path.resolve(__dirname, '..', '..', '..', 'out', 'cloned', 'emptySol');
 

--- a/src/actions/clone-solution/index.ts
+++ b/src/actions/clone-solution/index.ts
@@ -22,7 +22,6 @@ import { runnerParameters } from '../../lib/runnerParameters';
         credentials: getCredentials(),
         environmentUrl: getEnvironmentUrl(),
         name: parameterMap['solution-name'],
-        targetVersion: parameterMap['solution-version'],
         outputDirectory: parameterMap['target-folder'],
         async: parameterMap['async'],
         maxAsyncWaitTimeInMin: parameterMap['max-async-wait-time'],

--- a/src/actions/export-solution/index.ts
+++ b/src/actions/export-solution/index.ts
@@ -25,7 +25,6 @@ import { runnerParameters } from '../../lib/runnerParameters';
         name: parameterMap['solution-name'],
         path: parameterMap['solution-output-file'],
         managed: parameterMap['managed'],
-        targetVersion: parameterMap['solution-version'],
         async: parameterMap['run-asynchronously'],
         maxAsyncWaitTimeInMin: parameterMap['max-async-wait-time'],
         autoNumberSettings: parameterMap['export-auto-numbering-settings'],

--- a/src/test/exportSolution.test.ts
+++ b/src/test/exportSolution.test.ts
@@ -38,7 +38,6 @@ describe("export-solution tests", () => {
             name: { name: 'solution-name', required: true, defaultValue: undefined },
             path: { name: 'solution-output-file', required: true, defaultValue: undefined },
             managed: { name: 'managed', required: false, defaultValue: 'false' },
-            targetVersion: { name: 'solution-version', required: false, defaultValue: undefined },
             async: { name: 'run-asynchronously', required: false, defaultValue: 'false' },
             maxAsyncWaitTimeInMin: { name: 'max-async-wait-time', required: false, defaultValue: '60' },
             autoNumberSettings: { name: 'export-auto-numbering-settings', required: false, defaultValue: 'false' },

--- a/src/test/whoami.test.ts
+++ b/src/test/whoami.test.ts
@@ -16,6 +16,7 @@ should();
 use(sinonChai);
 
 describe("WhoAmI tests", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let coreSetOutputSpy: sinon.SinonSpy<[name: string, value: any], void>;
 
     beforeEach(() => {


### PR DESCRIPTION
Deprecate usage of targetVersion parameter for export-solution and clone-solution.
Also: use the `deprecationMessage` on input property definition to utilize the platform feature for deprecation.