### PR TITLE
move to nodejs v16

### DIFF
--- a/.azure-pipelines/ComplianceCheckBuild.yml
+++ b/.azure-pipelines/ComplianceCheckBuild.yml
@@ -28,9 +28,9 @@ pool:
 
 steps:
 - task: NodeTool@0
-  displayName: 'Use nodejs 14.x'
+  displayName: 'Use nodejs 16.x'
   inputs:
-    versionSpec: '14.x'
+    versionSpec: '16.x'
 
 # need to authenticate to npm package feed in microsoft/powerplatform-cli-wrapper (see also README.md)
 - task: npmAuthenticate@0

--- a/.github/workflows/paportal-rolling-instance-actions.yml
+++ b/.github/workflows/paportal-rolling-instance-actions.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2-beta
       with:
-        node-version: 14.x
+        node-version: 16.x
         registry-url: https://npm.pkg.github.com
 
     - name: Install NPM packages

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2-beta
       with:
-        node-version: 14.x
+        node-version: 16.x
         registry-url: https://npm.pkg.github.com
 
     - name: Build and test

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/who-am-i/index.js'
   # main: '../out/actions/who-am-i/index.js'

--- a/add-solution-component/action.yml
+++ b/add-solution-component/action.yml
@@ -44,5 +44,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/add-solution-component/index.js'

--- a/assign-user/action.yml
+++ b/assign-user/action.yml
@@ -45,5 +45,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/assign-user/index.js'

--- a/backup-environment/action.yml
+++ b/backup-environment/action.yml
@@ -46,5 +46,5 @@ inputs:
     default: 'Public'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/backup-environment/index.js'

--- a/branch-solution/action.yml
+++ b/branch-solution/action.yml
@@ -38,6 +38,6 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/branch-solution/index.js'
   # main: '../out/actions/branch-solution/index.js'

--- a/check-solution/action.yml
+++ b/check-solution/action.yml
@@ -49,6 +49,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/check-solution/index.js'
   # main: '../out/actions/check-solution/index.js'

--- a/clone-solution/action.yml
+++ b/clone-solution/action.yml
@@ -60,6 +60,6 @@ inputs:
     default: '60'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/clone-solution/index.js'
   # main: '../out/actions/clone-solution/index.js'

--- a/copy-environment/action.yml
+++ b/copy-environment/action.yml
@@ -59,5 +59,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/copy-environment/index.js'

--- a/create-environment/action.yml
+++ b/create-environment/action.yml
@@ -72,6 +72,6 @@ outputs:
     description: 'ID of the freshly created environment'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/create-environment/index.js'
   # main: '../out/actions/create-environment/index.js'

--- a/delete-environment/action.yml
+++ b/delete-environment/action.yml
@@ -42,5 +42,5 @@ inputs:
     default: 'Public'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/delete-environment/index.js'

--- a/delete-solution/action.yml
+++ b/delete-solution/action.yml
@@ -38,6 +38,6 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/delete-solution/index.js'
   # main: '../out/actions/delete-solution/index.js'

--- a/deploy-package/action.yml
+++ b/deploy-package/action.yml
@@ -41,5 +41,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/deploy-package/index.js'

--- a/download-paportal/action.yml
+++ b/download-paportal/action.yml
@@ -53,6 +53,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/download-paportal/index.js'
   #main: '../out/actions/download-paportal/index.js'

--- a/export-data/action.yml
+++ b/export-data/action.yml
@@ -45,6 +45,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/export-data/index.js'
 

--- a/export-solution/action.yml
+++ b/export-solution/action.yml
@@ -125,6 +125,6 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/export-solution/index.js'
   # main: '../out/actions/export-solution/index.js'

--- a/import-data/action.yml
+++ b/import-data/action.yml
@@ -37,6 +37,6 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/import-data/index.js'
 

--- a/import-solution/action.yml
+++ b/import-solution/action.yml
@@ -90,6 +90,6 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/import-solution/index.js'
   # main: '../out/actions/import-solution/index.js'

--- a/install-application/action.yml
+++ b/install-application/action.yml
@@ -36,5 +36,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/install-application/index.js'

--- a/pack-solution/action.yml
+++ b/pack-solution/action.yml
@@ -53,6 +53,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/pack-solution/index.js'
   # main: '../out/actions/pack-solution/index.js'

--- a/publish-solution/action.yml
+++ b/publish-solution/action.yml
@@ -43,6 +43,6 @@ inputs:
     default: 'Public'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/publish-solution/index.js'
   # main: '../out/actions/publish-solution/index.js'

--- a/reset-environment/action.yml
+++ b/reset-environment/action.yml
@@ -73,6 +73,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/reset-environment/index.js'
 

--- a/restore-environment/action.yml
+++ b/restore-environment/action.yml
@@ -58,5 +58,5 @@ inputs:
     default: 'Public'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/restore-environment/index.js'

--- a/unpack-solution/action.yml
+++ b/unpack-solution/action.yml
@@ -58,6 +58,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/unpack-solution/index.js'
   # main: '../out/actions/unpack-solution/index.js'

--- a/update-solution-version/action.yml
+++ b/update-solution-version/action.yml
@@ -24,6 +24,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/update-solution-version/index.js'
   # main: '../out/actions/update-solution-version/index.js'

--- a/upgrade-solution/action.yml
+++ b/upgrade-solution/action.yml
@@ -45,6 +45,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/upgrade-solution/index.js'
   # main: '../out/actions/upgrade-solution/index.js'

--- a/upload-paportal/action.yml
+++ b/upload-paportal/action.yml
@@ -45,6 +45,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/upload-paportal/index.js'
   #main: '../out/actions/upload-paportal/index.js'

--- a/who-am-i/action.yml
+++ b/who-am-i/action.yml
@@ -37,6 +37,6 @@ outputs:
     description: ID of the environment connected with
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: '../dist/actions/who-am-i/index.js'
   # main: '../out/actions/who-am-i/index.js'


### PR DESCRIPTION
extending PR #255 by @devenes (thx!) to also move the workflows and AzDO pipelines to node16

This move to a more modern node version was long overdue
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

see also rolling build validation:
https://github.com/microsoft/powerplatform-actions/actions/runs/3423508968

#250 