### PR TITLE
update all workflow actions/* to use their node16 releases

### DIFF
--- a/.github/workflows/paportal-rolling-instance-actions.yml
+++ b/.github/workflows/paportal-rolling-instance-actions.yml
@@ -33,12 +33,12 @@ jobs:
       PORTAL_MANIFEST_FILE_PATH: ./starter-portal/.portalconfig/*-manifest.yml
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         lfs: true
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
         registry-url: https://npm.pkg.github.com
@@ -100,7 +100,7 @@ jobs:
 
     - name: Upload pac CLI logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pac-cli-log ${{ matrix.os }}
         path: ./dist/pac*/tools/logs/pac-log.txt
@@ -121,7 +121,7 @@ jobs:
       PORTAL_MANIFEST_FILE_PATH: ./starter-portal/.portalconfig/*-manifest.yml
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         lfs: true
 
@@ -156,7 +156,7 @@ jobs:
 
     - name: Upload pac CLI logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pac-cli-log ${{ matrix.os }}
         path: ./dist/pac*/tools/logs/pac-log.txt

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,12 +21,12 @@ jobs:
       WF_APP_USER_ID: "82e66a08-8bf9-42bf-883a-7e2d17c7cede"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         lfs: true
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
         registry-url: https://npm.pkg.github.com
@@ -151,14 +151,14 @@ jobs:
 
     - name: Upload pac CLI logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pac-cli-log ${{ matrix.os }}
         path: ./dist/pac*/tools/logs/pac-log.txt
 
     - name: Upload test logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test Logs ${{ matrix.os }}
         path: ./out/logs/*-tests.log

--- a/.github/workflows/rolling-instance-actions.yml
+++ b/.github/workflows/rolling-instance-actions.yml
@@ -29,7 +29,7 @@ jobs:
       WF_APP_USER_ID: "82e66a08-8bf9-42bf-883a-7e2d17c7cede"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         lfs: true
 
@@ -253,7 +253,7 @@ jobs:
 
     - name: Upload pac CLI logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pac-cli-log ${{ matrix.os }}
         path: ./dist/pac*/tools/logs/pac-log.txt


### PR DESCRIPTION
this addresses the GH workflow warnings in recent runs:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2-beta, actions/upload-artifact@v2
```
