### PR TITLE
Fixed OrgSvcFactory in PluginBase

### DIFF
--- a/dist/pac/tools/templates/plugin/template_PluginBase.cs
+++ b/dist/pac/tools/templates/plugin/template_PluginBase.cs
@@ -196,7 +196,7 @@ namespace $safeprojectname$
 
             NotificationService = serviceProvider.Get<IServiceEndpointNotificationService>();
 
-            IOrganizationServiceFactory factory = serviceProvider.Get<IOrganizationServiceFactory>();
+            OrgSvcFactory = (IOrganizationServiceFactory)serviceprovider.GetService(typeof(IOrganizationServiceFactory));
 
             PluginUserService = serviceProvider.GetOrganizationService(PluginExecutionContext.UserId); // User that the plugin is registered to run as, Could be same as current user.
 


### PR DESCRIPTION
When new Plugin in initialized using `pac plugin init` command. The OrgSvcFactory & Notification Service is not available through ILocalPluginContext parameter and object reference error is thrown when trying to access these.

GetService method must be used here instead of Get Method.