### PR TITLE
Remove unused dependency Nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "mocha": "^9.2.0",
-        "nanoid": "^3.2.0",
         "node-fetch": "^2.6.7",
         "postcss": "^8.4.6",
         "ps-list": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "mocha": "^9.2.0",
-    "nanoid": "^3.2.0",
     "node-fetch": "^2.6.7",
     "postcss": "^8.4.6",
     "ps-list": "^7.2.0",


### PR DESCRIPTION
Removing unused Nanoid dependency.
(While we have a few transitive dependencies on Nanoid, we do not directly depend on it.)