### PR TITLE
Fix `branch-solution` for Ubuntu runners. Fixes #229

### DIFF
--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -18620,7 +18620,7 @@ var currDir = process.cwd();
     if (branch && branch.length >= 2) {
       return branch[1];
     }
-  });
+  }).filter(x => x !== undefined);
   if (!head || head.length < 1 || head.length > 1 || !head[0]) {
     throw new Error(`Cannot determine HEAD from remote: ${repoUrl}`);
   }

--- a/src/actions/branch-solution/index.ts
+++ b/src/actions/branch-solution/index.ts
@@ -59,7 +59,7 @@ const currDir = process.cwd();
         if (branch && branch.length >= 2) {
             return branch[1];
         }
-    });
+    }).filter(x => x !== undefined);
     if (!head || head.length < 1 || head.length > 1 || !head[0]) {
         throw new Error(`Cannot determine HEAD from remote: ${repoUrl}`);
     }


### PR DESCRIPTION
**Fixes #229 (again):**
Running with an ubuntu-latest runner, the `branch-solution` action fails with the message:
`Error: failed: Error: Cannot determine HEAD from remote: ...`

- previous fix worked: #236
- changes were made only in `dist` 
- fix was overwritten by 06bdb58

This PR reintroduces the fix, this time also in `src`.

In Windows, the current code is only working due to broken line-splitting of the command output (see #406).