### PR TITLE
Fix `branch-solution` for Ubuntu runners. Fixes #229

### DIFF
--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -18620,7 +18620,7 @@ var currDir = process.cwd();
     if (branch && branch.length >= 2) {
       return branch[1];
     }
-  }).filter(x => x !== undefined);
+  }).filter((x) => x !== void 0);
   if (!head || head.length < 1 || head.length > 1 || !head[0]) {
     throw new Error(`Cannot determine HEAD from remote: ${repoUrl}`);
   }

--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -18620,7 +18620,7 @@ var currDir = process.cwd();
     if (branch && branch.length >= 2) {
       return branch[1];
     }
-  });
+  }).filter(x => x !== undefined);
   if (!head || head.length < 1 || head.length > 1 || !head[0]) {
     throw new Error(`Cannot determine HEAD from remote: ${repoUrl}`);
   }

--- a/src/actions/branch-solution/index.ts
+++ b/src/actions/branch-solution/index.ts
@@ -59,7 +59,7 @@ const currDir = process.cwd();
         if (branch && branch.length >= 2) {
             return branch[1];
         }
-    });
+    }).filter(x => x !== undefined);
     if (!head || head.length < 1 || head.length > 1 || !head[0]) {
         throw new Error(`Cannot determine HEAD from remote: ${repoUrl}`);
     }


### PR DESCRIPTION
The GH security model won't let us access repo feed secrets used in the PR validation builds in PRs from forks.  
repo-local branch created from sccle:main, originally submitted as PR #405 
CC: @sccle 

> **Fixes #229 (again):** Running with an ubuntu-latest runner, the `branch-solution` action fails with the message: `Error: failed: Error: Cannot determine HEAD from remote: ...`
> 
> * previous fix worked: [Filter non-matching lines from git command. Fixes #229. #236](https://github.com/microsoft/powerplatform-actions/pull/236)
> * changes were made only in `dist`
> * fix was overwritten by [06bdb58](https://github.com/microsoft/powerplatform-actions/commit/06bdb58a5e4cae768c859089a9294b9e6f7cdd27)
> 
> This PR reintroduces the fix, this time also in `src`.
> 
> In Windows, the current code is only working due to broken line-splitting of the command output (see #406).

