### PR TITLE
Rolling Instance Build Fix

### DIFF
--- a/.github/workflows/paportal-rolling-instance-actions.yml
+++ b/.github/workflows/paportal-rolling-instance-actions.yml
@@ -129,6 +129,10 @@ jobs:
       with:
         lfs: true
 
+    - name: Install PAC
+      uses: ./actions-install
+      id: actions-install
+
     - name: Test paportal-download action with username/password
       uses: ./download-paportal
       with:


### PR DESCRIPTION
Forgot to add the install step to the second job of the `paportal-rolling-instance-actions` pipeline.