### PR TITLE
Better error messages and warnings

### DIFF
--- a/dist/actions/actions-install/index.js
+++ b/dist/actions/actions-install/index.js
@@ -3495,8 +3495,7 @@ function nugetInstall(packageName, packageVersion, installDir) {
     core.info(`Installing ${packageName}.${packageVersion} via nuget.exe`);
     core.debug(`Installing to ${installDir}`);
     const outputDirectory = (0, node_path_1.dirname)(installDir);
-    yield io.which("fakemcdoesntexist", true);
-    yield io.which("nuget", true);
+    yield checkForInstallationTool("nuget");
     yield exec.getExecOutput("nuget", [
       "install",
       packageName,
@@ -3515,7 +3514,7 @@ function nugetInstall(packageName, packageVersion, installDir) {
 function dotnetInstall(packageName, packageVersion, installDir) {
   return __awaiter(this, void 0, void 0, function* () {
     core.info(`Installing ${packageName}.${packageVersion} via dotnet tool install`);
-    yield io.which("dotnet", true);
+    yield checkForInstallationTool("dotnet");
     yield exec.getExecOutput("dotnet", [
       "tool",
       "install",
@@ -3525,5 +3524,14 @@ function dotnetInstall(packageName, packageVersion, installDir) {
       "--tool-path",
       installDir
     ]);
+  });
+}
+function checkForInstallationTool(toolName) {
+  return __awaiter(this, void 0, void 0, function* () {
+    try {
+      yield io.which(toolName, true);
+    } catch (error) {
+      throw new Error(`Runner does not have prerequisite "${toolName}" installed, as it was not found in the PATH.`);
+    }
   });
 }

--- a/dist/actions/actions-install/index.js
+++ b/dist/actions/actions-install/index.js
@@ -2695,7 +2695,7 @@ var require_toolrunner = __commonJS({
     var events = __importStar(require("events"));
     var child = __importStar(require("child_process"));
     var path = __importStar(require("path"));
-    var io = __importStar(require_io());
+    var io2 = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = require("timers");
     var IS_WINDOWS = process.platform === "win32";
@@ -2911,7 +2911,7 @@ var require_toolrunner = __commonJS({
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
             this.toolPath = path.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
-          this.toolPath = yield io.which(this.toolPath, true);
+          this.toolPath = yield io2.which(this.toolPath, true);
           return new Promise((resolve, reject) => __awaiter2(this, void 0, void 0, function* () {
             this._debug(`exec tool: ${this.toolPath}`);
             this._debug("arguments:");
@@ -3352,7 +3352,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",
@@ -3446,6 +3446,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.main = void 0;
 var core = require_core();
 var exec = require_exec();
+var io = require_io();
 var os = require("node:os");
 var node_path_1 = require("node:path");
 var fs = require("node:fs/promises");
@@ -3466,6 +3467,9 @@ function main() {
   return __awaiter(this, void 0, void 0, function* () {
     core.startGroup("actions-install:");
     const versionArg = core.getInput("pac-version-override", { required: false, trimWhitespace: true });
+    if (versionArg && versionArg !== PacInfo.PacPackageVersion) {
+      core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match with requested version ${versionArg}.`);
+    }
     const packageVersion = versionArg || PacInfo.PacPackageVersion;
     core.info(`Installing pac ${packageVersion}...`);
     if (process.env[runnerParameters_1.PacInstalledEnvVarName] === "true") {
@@ -3491,6 +3495,8 @@ function nugetInstall(packageName, packageVersion, installDir) {
     core.info(`Installing ${packageName}.${packageVersion} via nuget.exe`);
     core.debug(`Installing to ${installDir}`);
     const outputDirectory = (0, node_path_1.dirname)(installDir);
+    yield io.which("fakemcdoesntexist", true);
+    yield io.which("nuget", true);
     yield exec.getExecOutput("nuget", [
       "install",
       packageName,
@@ -3509,6 +3515,7 @@ function nugetInstall(packageName, packageVersion, installDir) {
 function dotnetInstall(packageName, packageVersion, installDir) {
   return __awaiter(this, void 0, void 0, function* () {
     core.info(`Installing ${packageName}.${packageVersion} via dotnet tool install`);
+    yield io.which("dotnet", true);
     yield exec.getExecOutput("dotnet", [
       "tool",
       "install",

--- a/dist/actions/add-solution-component/index.js
+++ b/dist/actions/add-solution-component/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/assign-group/index.js
+++ b/dist/actions/assign-group/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/assign-user/index.js
+++ b/dist/actions/assign-user/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/backup-environment/index.js
+++ b/dist/actions/backup-environment/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -2328,7 +2328,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/catalog-status/index.js
+++ b/dist/actions/catalog-status/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/check-solution/index.js
+++ b/dist/actions/check-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/clone-solution/index.js
+++ b/dist/actions/clone-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/copy-environment/index.js
+++ b/dist/actions/copy-environment/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/create-environment/index.js
+++ b/dist/actions/create-environment/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/delete-environment/index.js
+++ b/dist/actions/delete-environment/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/delete-solution/index.js
+++ b/dist/actions/delete-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/deploy-package/index.js
+++ b/dist/actions/deploy-package/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/download-paportal/index.js
+++ b/dist/actions/download-paportal/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/export-data/index.js
+++ b/dist/actions/export-data/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/export-solution/index.js
+++ b/dist/actions/export-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/import-data/index.js
+++ b/dist/actions/import-data/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/import-solution/index.js
+++ b/dist/actions/import-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/install-catalog/index.js
+++ b/dist/actions/install-catalog/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/pack-solution/index.js
+++ b/dist/actions/pack-solution/index.js
@@ -24108,7 +24108,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/publish-solution/index.js
+++ b/dist/actions/publish-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/reset-environment/index.js
+++ b/dist/actions/reset-environment/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/restore-environment/index.js
+++ b/dist/actions/restore-environment/index.js
@@ -24156,7 +24156,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/set-online-solution-version/index.js
+++ b/dist/actions/set-online-solution-version/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/submit-catalog/index.js
+++ b/dist/actions/submit-catalog/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/unpack-solution/index.js
+++ b/dist/actions/unpack-solution/index.js
@@ -24108,7 +24108,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/update-solution-version/index.js
+++ b/dist/actions/update-solution-version/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/upgrade-solution/index.js
+++ b/dist/actions/upgrade-solution/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/upload-paportal/index.js
+++ b/dist/actions/upload-paportal/index.js
@@ -24169,7 +24169,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/dist/actions/who-am-i/index.js
+++ b/dist/actions/who-am-i/index.js
@@ -14167,7 +14167,7 @@ var require_package = __commonJS({
         "gulp-typescript": "^6.0.0-alpha.1",
         mocha: "^10.2.0",
         "node-fetch": "^3.3.1",
-        postcss: "^8.4.25",
+        postcss: "^8.4.28",
         "ps-list": "^8.1.1",
         rewiremock: "^3.14.5",
         sinon: "^15.2.0",

--- a/src/actions/actions-install/index.ts
+++ b/src/actions/actions-install/index.ts
@@ -59,10 +59,8 @@ async function nugetInstall(packageName: string, packageVersion: string, install
 
     const outputDirectory = dirname(installDir);
 
-    // Testing output with noexistant tool - DO NOT COMMIT TO MAIN
-    await io.which('fakemcdoesntexist', true);
+    await checkForInstallationTool('nuget');
 
-    await io.which('nuget', true);
     await exec.getExecOutput('nuget', ['install', packageName,
         '-Version', packageVersion,
         '-DependencyVersion', 'ignore', // There are no dependencies, so don't waste that time checking
@@ -78,8 +76,17 @@ async function nugetInstall(packageName: string, packageVersion: string, install
 async function dotnetInstall(packageName: string, packageVersion: string, installDir: string): Promise<void> {
     core.info(`Installing ${packageName}.${packageVersion} via dotnet tool install`);
 
-    await io.which('dotnet', true);
+    await checkForInstallationTool('dotnet');
+
     await exec.getExecOutput('dotnet', ['tool', 'install', packageName,
         '--version', packageVersion,
         '--tool-path', installDir]);
+}
+
+async function checkForInstallationTool(toolName: string): Promise<void> {
+    try {
+        await io.which(toolName, true);
+    } catch (error) {
+        throw new Error(`Runner does not have prerequisite "${toolName}" installed, as it was not found in the PATH.`);
+    }
 }

--- a/src/actions/actions-install/index.ts
+++ b/src/actions/actions-install/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import * as io from '@actions/io'
 import * as os from "node:os";
 import { dirname, resolve } from 'node:path';
 import * as fs from 'node:fs/promises';
@@ -23,6 +24,11 @@ import { PacInstalledEnvVarName } from '../../lib/runnerParameters';
 export async function main(): Promise<void> {
     core.startGroup('actions-install:');
     const versionArg = core.getInput('pac-version-override', { required: false, trimWhitespace: true });
+
+    if (versionArg && versionArg !== PacInfo.PacPackageVersion) {
+        core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match with requested version ${versionArg}.`);
+    }
+
     const packageVersion = versionArg || PacInfo.PacPackageVersion;
 
     core.info(`Installing pac ${packageVersion}...`);
@@ -53,6 +59,10 @@ async function nugetInstall(packageName: string, packageVersion: string, install
 
     const outputDirectory = dirname(installDir);
 
+    // Testing output with noexistant tool - DO NOT COMMIT TO MAIN
+    await io.which('fakemcdoesntexist', true);
+
+    await io.which('nuget', true);
     await exec.getExecOutput('nuget', ['install', packageName,
         '-Version', packageVersion,
         '-DependencyVersion', 'ignore', // There are no dependencies, so don't waste that time checking
@@ -68,6 +78,7 @@ async function nugetInstall(packageName: string, packageVersion: string, install
 async function dotnetInstall(packageName: string, packageVersion: string, installDir: string): Promise<void> {
     core.info(`Installing ${packageName}.${packageVersion} via dotnet tool install`);
 
+    await io.which('dotnet', true);
     await exec.getExecOutput('dotnet', ['tool', 'install', packageName,
         '--version', packageVersion,
         '--tool-path', installDir]);


### PR DESCRIPTION
The Install step now emits a warning when a different version of pac is requested with the override parameter, to make it clearer that it might not be compatible with other actions at runtime.

And added checks io the install step to check if nuget.exe / dotnet SDK are installed for Windows / Linux agents respectively.