### PR TITLE
Fixes for the two Solution Version actions

### DIFF
--- a/dist/actions/actions-install/index.js
+++ b/dist/actions/actions-install/index.js
@@ -3369,7 +3369,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/add-solution-component/index.js
+++ b/dist/actions/add-solution-component/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/assign-group/index.js
+++ b/dist/actions/assign-group/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/assign-user/index.js
+++ b/dist/actions/assign-user/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/backup-environment/index.js
+++ b/dist/actions/backup-environment/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -2345,7 +2345,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/catalog-status/index.js
+++ b/dist/actions/catalog-status/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/check-solution/index.js
+++ b/dist/actions/check-solution/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/clone-solution/index.js
+++ b/dist/actions/clone-solution/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/copy-environment/index.js
+++ b/dist/actions/copy-environment/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/create-environment/index.js
+++ b/dist/actions/create-environment/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/delete-environment/index.js
+++ b/dist/actions/delete-environment/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/delete-solution/index.js
+++ b/dist/actions/delete-solution/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/deploy-package/index.js
+++ b/dist/actions/deploy-package/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/download-paportal/index.js
+++ b/dist/actions/download-paportal/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/export-data/index.js
+++ b/dist/actions/export-data/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/export-solution/index.js
+++ b/dist/actions/export-solution/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/import-data/index.js
+++ b/dist/actions/import-data/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/import-solution/index.js
+++ b/dist/actions/import-solution/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/install-catalog/index.js
+++ b/dist/actions/install-catalog/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/pack-solution/index.js
+++ b/dist/actions/pack-solution/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24125,7 +24190,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/publish-solution/index.js
+++ b/dist/actions/publish-solution/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/reset-environment/index.js
+++ b/dist/actions/reset-environment/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/restore-environment/index.js
+++ b/dist/actions/restore-environment/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24173,7 +24238,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/set-online-solution-version/index.js
+++ b/dist/actions/set-online-solution-version/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/submit-catalog/index.js
+++ b/dist/actions/submit-catalog/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/unpack-solution/index.js
+++ b/dist/actions/unpack-solution/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24125,7 +24190,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/update-solution-version/index.js
+++ b/dist/actions/update-solution-version/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -23999,67 +24064,6 @@ var require_ActionsHost = __commonJS({
   }
 });
 
-// out/lib/auth/getCredentials.js
-var require_getCredentials = __commonJS({
-  "out/lib/auth/getCredentials.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var core_1 = require_core();
-    function getCredentials() {
-      const usernamePassword = {
-        username: getInput("user-name"),
-        password: getInput("password-secret"),
-        encodePassword: true,
-        cloudInstance: getInput("cloud")
-      };
-      const isUpValid = isUsernamePasswordValid(usernamePassword);
-      const clientCredentials = {
-        appId: getInput("app-id"),
-        clientSecret: getInput("client-secret"),
-        encodeSecret: true,
-        tenantId: getInput("tenant-id"),
-        cloudInstance: getInput("cloud"),
-        scheme: ""
-        // no MgtIdentity support for Actions yet
-      };
-      const isCcValid = isClientCredentialsValid(clientCredentials);
-      if (isUpValid && isCcValid) {
-        throw new Error("Too many authentication parameters specified. Must pick either username/password or app-id/client-secret/tenant-id for the authentication flow.");
-      }
-      if (isUpValid) {
-        return usernamePassword;
-      }
-      if (isCcValid) {
-        return clientCredentials;
-      }
-      throw new Error("Must provide either username/password or app-id/client-secret/tenant-id for authentication!");
-    }
-    exports2.default = getCredentials;
-    function getInput(name) {
-      return (0, core_1.getInput)(name, { required: false });
-    }
-    function isUsernamePasswordValid(usernamePassword) {
-      return !!usernamePassword.username && !!usernamePassword.password;
-    }
-    function isClientCredentialsValid(clientCredentials) {
-      return !!clientCredentials.appId && !!clientCredentials.clientSecret && !!clientCredentials.tenantId;
-    }
-  }
-});
-
-// out/lib/auth/getEnvironmentUrl.js
-var require_getEnvironmentUrl = __commonJS({
-  "out/lib/auth/getEnvironmentUrl.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var core_1 = require_core();
-    function getEnvironmentUrl() {
-      return (0, core_1.getInput)("environment-url", { required: false });
-    }
-    exports2.default = getEnvironmentUrl;
-  }
-});
-
 // out/lib/actionLogger.js
 var require_actionLogger = __commonJS({
   "out/lib/actionLogger.js"(exports2) {
@@ -24186,7 +24190,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24265,8 +24269,6 @@ var core = require_core();
 var actions_1 = require_actions();
 var YamlParser_1 = require_YamlParser();
 var ActionsHost_1 = require_ActionsHost();
-var getCredentials_1 = require_getCredentials();
-var getEnvironmentUrl_1 = require_getEnvironmentUrl();
 var runnerParameters_1 = require_runnerParameters();
 (() => __awaiter(void 0, void 0, void 0, function* () {
   if (process.env.GITHUB_ACTIONS) {
@@ -24280,8 +24282,6 @@ function main() {
       const taskParser = new YamlParser_1.YamlParser();
       const parameterMap = taskParser.getHostParameterEntries("update-solution-version");
       yield (0, actions_1.updateVersionSolution)({
-        credentials: (0, getCredentials_1.default)(),
-        environmentUrl: (0, getEnvironmentUrl_1.default)(),
         buildVersion: parameterMap["build-version"],
         revisionVersion: parameterMap["revision-version"],
         patchVersion: parameterMap["patch-version"],

--- a/dist/actions/upgrade-solution/index.js
+++ b/dist/actions/upgrade-solution/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/upload-paportal/index.js
+++ b/dist/actions/upload-paportal/index.js
@@ -13027,15 +13027,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -13050,9 +13047,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -13936,6 +13930,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -13994,6 +14058,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -24186,7 +24251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/dist/actions/who-am-i/index.js
+++ b/dist/actions/who-am-i/index.js
@@ -10861,15 +10861,12 @@ var require_updateVersionSolution = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.updateVersionSolution = void 0;
     var InputValidator_1 = require_InputValidator();
-    var authenticate_1 = require_authenticate();
     var createPacRunner_1 = require_createPacRunner();
     function updateVersionSolution(parameters, runnerParameters, host) {
       return __awaiter2(this, void 0, void 0, function* () {
         const logger = runnerParameters.logger;
         const pac = (0, createPacRunner_1.default)(runnerParameters);
         try {
-          const authenticateResult = yield (0, authenticate_1.authenticateEnvironment)(pac, parameters.credentials, parameters.environmentUrl, logger);
-          logger.log("The Authentication Result: " + authenticateResult);
           const pacArgs = ["solution", "version"];
           const validator = new InputValidator_1.InputValidator(host);
           validator.pushInput(pacArgs, "--buildversion", parameters.buildVersion);
@@ -10884,9 +10881,6 @@ var require_updateVersionSolution = __commonJS({
         } catch (error) {
           logger.error(`failed: ${error instanceof Error ? error.message : error}`);
           throw error;
-        } finally {
-          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
-          logger.log("The Clear Authentication Result: " + clearAuthResult);
         }
       });
     }
@@ -11770,6 +11764,76 @@ var require_updateOrgSettings = __commonJS({
   }
 });
 
+// node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js
+var require_setGovernanceConfig = __commonJS({
+  "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/setGovernanceConfig.js"(exports2) {
+    "use strict";
+    var __awaiter2 = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve) {
+          resolve(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.setGovernanceConfig = void 0;
+    var InputValidator_1 = require_InputValidator();
+    var authenticate_1 = require_authenticate();
+    var createPacRunner_1 = require_createPacRunner();
+    function setGovernanceConfig(parameters, runnerParameters, host) {
+      return __awaiter2(this, void 0, void 0, function* () {
+        const logger = runnerParameters.logger;
+        const pac = (0, createPacRunner_1.default)(runnerParameters);
+        const pacArgs = ["admin", "set-governance-config"];
+        const validator = new InputValidator_1.InputValidator(host);
+        try {
+          const authenticateResult = yield (0, authenticate_1.authenticateAdmin)(pac, parameters.credentials, logger);
+          logger.log("The Authentication Result: " + authenticateResult);
+          validator.pushInput(pacArgs, "--environment", parameters.environment);
+          validator.pushInput(pacArgs, "--protection-level", parameters.protectionLevel);
+          validator.pushInput(pacArgs, "--disable-group-sharing", parameters.disableGroupSharing);
+          validator.pushInput(pacArgs, "--exclude-analysis", parameters.excludeAnalysis);
+          validator.pushInput(pacArgs, "--include-insights", parameters.includeInsights);
+          validator.pushInput(pacArgs, "--limit-sharing-mode", parameters.limitSharingMode);
+          validator.pushInput(pacArgs, "--max-limit-user-sharing", parameters.maxLimitUserSharing);
+          validator.pushInput(pacArgs, "--solution-checker-mode", parameters.solutionCheckerMode);
+          validator.pushCommon(pacArgs, parameters);
+          logger.log("Calling pac cli inputs: " + pacArgs.join(" "));
+          const pacResult = yield pac(...pacArgs);
+          logger.log("SetGovernanceConfig Action Result: " + pacResult);
+        } catch (error) {
+          logger.error(`failed: ${error instanceof Error ? error.message : error}`);
+          throw error;
+        } finally {
+          const clearAuthResult = yield (0, authenticate_1.clearAuthentication)(pac);
+          logger.log("The Clear Authentication Result: " + clearAuthResult);
+        }
+      });
+    }
+    exports2.setGovernanceConfig = setGovernanceConfig;
+  }
+});
+
 // node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js
 var require_actions = __commonJS({
   "node_modules/@microsoft/powerplatform-cli-wrapper/dist/actions/index.js"(exports2) {
@@ -11828,6 +11892,7 @@ var require_actions = __commonJS({
     __exportStar(require_submitCatalog(), exports2);
     __exportStar(require_pipelineDeploy(), exports2);
     __exportStar(require_updateOrgSettings(), exports2);
+    __exportStar(require_setGovernanceConfig(), exports2);
   }
 });
 
@@ -14184,7 +14249,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.110",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.110/84cac6b48d5422154d5f067f68e5acc4f97d9612",
-      "integrity": "sha512-f65SjBSZaZlm4si77g1gPA/7czk67xW0ye0aXji40wWYOTkV1K676+zhgaTpIzvUMoyKR1pXPByBb4cF8ZngoA==",
+      "version": "0.1.113",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.113/bdacd2401bc69129d1ba4ec33b76795a90c123bd",
+      "integrity": "sha512-bxEDFJpIoEH8qRJj/psIfnBZvli0MOxL+mDV2qYGQ/dkTmXnPQkpobyZpsKLcMnAEc16A3UVUOBW5AlnU9lOCQ==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -11100,9 +11100,9 @@
       }
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.110",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.110/84cac6b48d5422154d5f067f68e5acc4f97d9612",
-      "integrity": "sha512-f65SjBSZaZlm4si77g1gPA/7czk67xW0ye0aXji40wWYOTkV1K676+zhgaTpIzvUMoyKR1pXPByBb4cF8ZngoA==",
+      "version": "0.1.113",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.113/bdacd2401bc69129d1ba4ec33b76795a90c123bd",
+      "integrity": "sha512-bxEDFJpIoEH8qRJj/psIfnBZvli0MOxL+mDV2qYGQ/dkTmXnPQkpobyZpsKLcMnAEc16A3UVUOBW5AlnU9lOCQ==",
       "requires": {
         "fs-extra": "^11.1.1",
         "glob": "^10.3.3"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.3",
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.110",
+    "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
     "date-fns": "^2.30.0",
     "fs-extra": "^11.1.1",
     "js-yaml": "^4.1",

--- a/set-online-solution-version/action.yml
+++ b/set-online-solution-version/action.yml
@@ -3,6 +3,30 @@
 name: 'set-online-solution-version'
 description: 'Power Platform Set Online Solution Version'
 inputs:
+  user-name:
+      description: 'Power Platform user name to authenticate with, e.g. myname@my-org.onmicrosoft.com. Setting this input makes user-name and password required; specifying alternate "app-id" credential set of inputs will result in an error.'
+      required: false
+
+  password-secret:
+    description: 'Power Platform password, required if authenticating with username. Do NOT check in password, instead create a secret and reference it here with: see: https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow'
+    required: false
+
+  app-id:
+    description: 'The application id to authenticate with. Setting this input makes app-id, tenant-id and client-secret required; specifying alternate "username" credential set of inputs will result in an error.'
+    required: false
+
+  client-secret:
+    description: 'The client secret to authenticate with. Required if authenticating with app-id.'
+    required: false
+
+  tenant-id:
+    description: 'Tenant id if using app-id & client secret to authenticate.'
+    required: false
+
+  environment:
+    description: 'Id or URL of Power Platform environment to assign user to.'
+    required: true
+
   name:
     description: 'Name of the solution'
     required: true

--- a/set-online-solution-version/action.yml
+++ b/set-online-solution-version/action.yml
@@ -3,6 +3,10 @@
 name: 'set-online-solution-version'
 description: 'Power Platform Set Online Solution Version'
 inputs:
+  environment-url:
+    description: 'URL of Power Platform environment to connect with; e.g. "https://test-env.crm.dynamics.com"'
+    required: true
+
   user-name:
       description: 'Power Platform user name to authenticate with, e.g. myname@my-org.onmicrosoft.com. Setting this input makes user-name and password required; specifying alternate "app-id" credential set of inputs will result in an error.'
       required: false
@@ -22,10 +26,6 @@ inputs:
   tenant-id:
     description: 'Tenant id if using app-id & client secret to authenticate.'
     required: false
-
-  environment:
-    description: 'Id or URL of Power Platform environment to assign user to.'
-    required: true
 
   name:
     description: 'Name of the solution'

--- a/src/actions/update-solution-version/index.ts
+++ b/src/actions/update-solution-version/index.ts
@@ -4,8 +4,6 @@ import * as core from '@actions/core';
 import { updateVersionSolution } from "@microsoft/powerplatform-cli-wrapper/dist/actions";
 import { YamlParser } from '../../lib/parser/YamlParser';
 import { ActionsHost } from '../../lib/host/ActionsHost';
-import getCredentials from "../../lib/auth/getCredentials";
-import getEnvironmentUrl from "../../lib/auth/getEnvironmentUrl";
 import { runnerParameters } from "../../lib/runnerParameters";
 
 (async () => {
@@ -21,8 +19,6 @@ export async function main(): Promise<void> {
         const parameterMap = taskParser.getHostParameterEntries('update-solution-version');
 
         await updateVersionSolution({
-            credentials: getCredentials(),
-            environmentUrl: getEnvironmentUrl(),
             buildVersion: parameterMap['build-version'],
             revisionVersion: parameterMap['revision-version'],
             patchVersion: parameterMap['patch-version'],

--- a/src/test/updateSolutionVersion.test.ts
+++ b/src/test/updateSolutionVersion.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { should, use } from "chai";
-import { stubInterface } from "ts-sinon";
 import * as sinonChai from "sinon-chai";
 import rewiremock from "./rewiremock";
 import { fake, stub } from "sinon";

--- a/src/test/updateSolutionVersion.test.ts
+++ b/src/test/updateSolutionVersion.test.ts
@@ -6,7 +6,6 @@ import { stubInterface } from "ts-sinon";
 import * as sinonChai from "sinon-chai";
 import rewiremock from "./rewiremock";
 import { fake, stub } from "sinon";
-import { UsernamePassword } from "@microsoft/powerplatform-cli-wrapper";
 import { runnerParameters } from "../../src/lib/runnerParameters";
 import Sinon = require("sinon");
 import { ActionsHost } from "../lib/host/ActionsHost";
@@ -16,16 +15,12 @@ use(sinonChai);
 describe("update version solution test", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateVersionSolutionStub: Sinon.SinonStub<any[], any> = stub();
-  const credentials: UsernamePassword = stubInterface<UsernamePassword>();
-  const environmentUrl = "environment url";
 
   async function callActionWithMocks(): Promise<void> {
     const updateVersionSolution = await rewiremock.around(
       () => import("../../src/actions/update-solution-version/index"),
       (mock) => {
         mock(() => import("@microsoft/powerplatform-cli-wrapper/dist/actions")).with({ updateVersionSolution: updateVersionSolutionStub });
-        mock(() => import("../../src/lib/auth/getCredentials")).withDefault(() => credentials );
-        mock(() => import("../../src/lib/auth/getEnvironmentUrl")).withDefault(() => environmentUrl );
         mock(() => import("fs/promises")).with({ chmod: fake() });
         mock(() => import("../../src/lib/runnerParameters")).with({ runnerParameters: runnerParameters });
       });
@@ -37,8 +32,6 @@ describe("update version solution test", () => {
     await callActionWithMocks();
 
     updateVersionSolutionStub.should.have.been.calledWithExactly({
-      credentials: credentials,
-      environmentUrl: environmentUrl,
       buildVersion: { name: 'build-version', required: false, defaultValue: undefined },
       revisionVersion: { name: 'revision-version', required: false, defaultValue: undefined },
       patchVersion: { name: 'patch-version', required: false, defaultValue: undefined },


### PR DESCRIPTION
Addressing #417

`set-online-solution-version` which calls `pac solution online-version` requires Authentication, but the auth parameters were missing from its definition yml

`update-solution-version` which calls `pac solution version` mistakenly required Authentication, but the underlying PAC command does not need any authentication as it merely manipulates local files with no service communication.