### PR TITLE
Updating actions-install to permit overriding the nuget feed

### DIFF
--- a/actions-install/action.yml
+++ b/actions-install/action.yml
@@ -1,10 +1,27 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 name: 'actions-install'
-description: 'Power Platform Actions Install'
+description: 'Power Platform Actions Install -- Installs the Power Platform CLI (pac) for use in other actions.  Pulls from nuget.org if arguments are not provided.'
 inputs:
+  nuget-feed-override:
+    description: 'Override the nuget feed used to pull the PAC package.  This can be a local folder containing pre-downloaded packages.  Defaults to nuget.org.'
+    required: false
+    # default: 'https://api.nuget.org/v3/index.json'
+
+  nuget-feed-username:
+    description: 'Optional username for feed provided in nuget-feed-override if it requires username + password authentication.'
+    required: false
+
+  nuget-feed-password:
+    description: 'Optional password for feed provided in nuget-feed-override if it requires username + password authentication.  Do NOT check in password, instead create a secret and reference it here with: see: https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow'
+    required: false
+
   pac-version-override:
     description: 'Override the version of PAC installed for Actions. Note that this may break other actions if the PAC and Action arguments do not align.'
+    required: false
+
+  use-preinstalled-pac:
+    description: 'Path to a pac.exe (windows) or pac (linux/mac) already installed on the action runner.'
     required: false
 
 runs:

--- a/dist/actions/actions-install/index.js
+++ b/dist/actions/actions-install/index.js
@@ -1954,7 +1954,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
-    var path = __importStar(require("path"));
+    var path2 = __importStar(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -1964,7 +1964,7 @@ var require_path_utils = __commonJS({
     }
     exports2.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path.sep);
+      return pth.replace(/[/\\]/g, path2.sep);
     }
     exports2.toPlatformPath = toPlatformPath;
   }
@@ -2035,7 +2035,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os2 = __importStar(require("os"));
-    var path = __importStar(require("path"));
+    var path2 = __importStar(require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -2063,7 +2063,7 @@ var require_core = __commonJS({
       } else {
         command_1.issueCommand("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
     function getInput(name, options) {
@@ -2262,7 +2262,7 @@ var require_io_util = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.READONLY = exports2.UV_FS_O_EXLOCK = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rm = exports2.rename = exports2.readlink = exports2.readdir = exports2.open = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
     var fs2 = __importStar(require("fs"));
-    var path = __importStar(require("path"));
+    var path2 = __importStar(require("path"));
     _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     exports2.UV_FS_O_EXLOCK = 268435456;
@@ -2311,7 +2311,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path.extname(filePath).toUpperCase();
+            const upperExt = path2.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -2335,11 +2335,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path.dirname(filePath);
-                const upperName = path.basename(filePath).toUpperCase();
+                const directory = path2.dirname(filePath);
+                const upperName = path2.basename(filePath).toUpperCase();
                 for (const actualName of yield exports2.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path.join(directory, actualName);
+                    filePath = path2.join(directory, actualName);
                     break;
                   }
                 }
@@ -2439,7 +2439,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
     var assert_1 = require("assert");
-    var path = __importStar(require("path"));
+    var path2 = __importStar(require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter2(this, void 0, void 0, function* () {
@@ -2448,7 +2448,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path.join(dest, path.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -2460,7 +2460,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path.relative(source, newDest) === "") {
+          if (path2.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -2473,7 +2473,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path.join(dest, path.basename(source));
+            dest = path2.join(dest, path2.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -2484,7 +2484,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path.dirname(dest));
+        yield mkdirP(path2.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -2547,7 +2547,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -2560,12 +2560,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path.sep)) {
+        if (tool.includes(path2.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path.delimiter)) {
+          for (const p of process.env.PATH.split(path2.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -2573,7 +2573,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -2694,7 +2694,7 @@ var require_toolrunner = __commonJS({
     var os2 = __importStar(require("os"));
     var events = __importStar(require("events"));
     var child = __importStar(require("child_process"));
-    var path = __importStar(require("path"));
+    var path2 = __importStar(require("path"));
     var io2 = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = require("timers");
@@ -2909,7 +2909,7 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter2(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io2.which(this.toolPath, true);
           return new Promise((resolve, reject) => __awaiter2(this, void 0, void 0, function* () {
@@ -3231,33 +3231,6 @@ var require_exec = __commonJS({
   }
 });
 
-// out/lib/getExePath.js
-var require_getExePath = __commonJS({
-  "out/lib/getExePath.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    var path_1 = require("path");
-    function getExePath(...relativePath) {
-      const currentDirectory = (0, path_1.resolve)(__dirname);
-      const parentDir = (0, path_1.dirname)(currentDirectory);
-      let outDirRoot;
-      switch ((0, path_1.basename)(parentDir)) {
-        case "actions":
-          outDirRoot = (0, path_1.resolve)((0, path_1.dirname)(parentDir));
-          break;
-        case "src":
-        case "out":
-          outDirRoot = (0, path_1.resolve)(parentDir, "..", "out");
-          break;
-        default:
-          throw Error(`ExeRunner: cannot resolve outDirRoot running from this location: ${path_1.dirname}`);
-      }
-      return (0, path_1.resolve)(outDirRoot, ...relativePath);
-    }
-    exports2.default = getExePath;
-  }
-});
-
 // out/lib/actionLogger.js
 var require_actionLogger = __commonJS({
   "out/lib/actionLogger.js"(exports2) {
@@ -3297,6 +3270,33 @@ var require_pacPackageInfo = __commonJS({
       DotnetToolName: "Microsoft.PowerApps.CLI.Tool",
       PacPackageVersion: "1.26.5"
     };
+  }
+});
+
+// out/lib/getExePath.js
+var require_getExePath = __commonJS({
+  "out/lib/getExePath.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    var path_1 = require("path");
+    function getExePath(...relativePath) {
+      const currentDirectory = (0, path_1.resolve)(__dirname);
+      const parentDir = (0, path_1.dirname)(currentDirectory);
+      let outDirRoot;
+      switch ((0, path_1.basename)(parentDir)) {
+        case "actions":
+          outDirRoot = (0, path_1.resolve)((0, path_1.dirname)(parentDir));
+          break;
+        case "src":
+        case "out":
+          outDirRoot = (0, path_1.resolve)(parentDir, "..", "out");
+          break;
+        default:
+          throw Error(`ExeRunner: cannot resolve outDirRoot running from this location: ${path_1.dirname}`);
+      }
+      return (0, path_1.resolve)(outDirRoot, ...relativePath);
+    }
+    exports2.default = getExePath;
   }
 });
 
@@ -3369,7 +3369,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -3384,12 +3384,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_12 = require_actionLogger();
-    var getExePath_12 = require_getExePath();
+    var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -3398,15 +3400,16 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_12.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {
           throw new Error(`PAC is not installed. Please run the actions-install action first.`);
         }
-        return (0, getExePath_12.default)();
+        return (0, getExePath_1.default)();
       }
     };
     var runnerParameters = new ActionsRunnerParameters();
@@ -3450,10 +3453,22 @@ var io = require_io();
 var os = require("node:os");
 var node_path_1 = require("node:path");
 var fs = require("node:fs/promises");
-var getExePath_1 = require_getExePath();
+var path = require("node:path");
 var actionLogger_1 = require_actionLogger();
 var PacInfo = require_pacPackageInfo();
 var runnerParameters_1 = require_runnerParameters();
+var argName = {
+  versionOverride: "pac-version-override",
+  nugetFeedOverride: "nuget-feed-override",
+  nugetFeedUsername: "nuget-feed-username",
+  nugetFeedPassword: "nuget-feed-password",
+  localPacPath: "use-preinstalled-pac"
+};
+var MutuallyExclusiveArgsError = class extends Error {
+  constructor(argument1, argument2) {
+    super(`Cannot specify both ${argument1} and ${argument2}.`);
+  }
+};
 (() => __awaiter(void 0, void 0, void 0, function* () {
   if (process.env.GITHUB_ACTIONS) {
     yield main();
@@ -3466,64 +3481,132 @@ var runnerParameters_1 = require_runnerParameters();
 function main() {
   return __awaiter(this, void 0, void 0, function* () {
     core.startGroup("actions-install:");
-    const versionArg = core.getInput("pac-version-override", { required: false, trimWhitespace: true });
-    if (versionArg && versionArg !== PacInfo.PacPackageVersion) {
-      core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match with requested version ${versionArg}.`);
+    const args = {
+      versionOverride: core.getInput(argName.versionOverride, { required: false }),
+      nugetFeedOverride: core.getInput(argName.nugetFeedOverride, { required: false }),
+      nugetFeedUsername: core.getInput(argName.nugetFeedUsername, { required: false }),
+      nugetFeedPassword: core.getInput(argName.nugetFeedPassword, { required: false }),
+      localPacPath: core.getInput(argName.localPacPath, { required: false })
+    };
+    args.nugetFeedPassword && core.setSecret(args.nugetFeedPassword);
+    if (args.localPacPath && args.nugetFeedOverride)
+      throw new MutuallyExclusiveArgsError(argName.localPacPath, argName.nugetFeedOverride);
+    if (args.localPacPath && args.versionOverride)
+      throw new MutuallyExclusiveArgsError(argName.localPacPath, argName.versionOverride);
+    if (args.nugetFeedPassword && !args.nugetFeedOverride) {
+      throw new Error(`Do not provide Authentication args (${argName.nugetFeedPassword}) without providing a feed which requires authentication via ${argName.nugetFeedOverride}.`);
     }
-    const packageVersion = versionArg || PacInfo.PacPackageVersion;
-    core.info(`Installing pac ${packageVersion}...`);
+    if (args.nugetFeedPassword && !args.nugetFeedUsername || !args.nugetFeedPassword && args.nugetFeedUsername) {
+      throw new Error(`Cannot specify ${argName.nugetFeedPassword} or ${argName.nugetFeedUsername} without the other.`);
+    }
+    if (args.versionOverride && args.versionOverride !== PacInfo.PacPackageVersion) {
+      core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match with requested version ${args.versionOverride}.`);
+    }
     if (process.env[runnerParameters_1.PacInstalledEnvVarName] === "true") {
       core.warning("PAC is already installed. Skipping installation.");
       core.endGroup();
       return;
     }
-    const runnersDir = (0, getExePath_1.default)();
-    if (os.platform() === "win32") {
-      const installDir = (0, node_path_1.resolve)(runnersDir, "pac");
-      yield nugetInstall(PacInfo.PacPackageName, packageVersion, installDir);
+    const packageVersion = args.versionOverride || PacInfo.PacPackageVersion;
+    if (args.localPacPath) {
+      yield usingPreinstalledPac(args.localPacPath);
+    } else if (os.platform() === "win32") {
+      yield nugetInstall(PacInfo.PacPackageName, packageVersion, args.nugetFeedOverride, args.nugetFeedUsername, args.nugetFeedPassword);
     } else {
-      const installDir = (0, node_path_1.resolve)(runnersDir, "pac_linux", "tools");
-      yield dotnetInstall(PacInfo.DotnetToolName, packageVersion, installDir);
+      yield dotnetInstall(PacInfo.DotnetToolName, packageVersion, args.nugetFeedOverride, args.nugetFeedUsername, args.nugetFeedPassword);
     }
-    core.exportVariable(runnerParameters_1.PacInstalledEnvVarName, "true");
     core.endGroup();
   });
 }
 exports.main = main;
-function nugetInstall(packageName, packageVersion, installDir) {
+function usingPreinstalledPac(localPacPath) {
   return __awaiter(this, void 0, void 0, function* () {
-    core.info(`Installing ${packageName}.${packageVersion} via nuget.exe`);
-    core.debug(`Installing to ${installDir}`);
-    const outputDirectory = (0, node_path_1.dirname)(installDir);
-    yield checkForInstallationTool("nuget");
-    yield exec.getExecOutput("nuget", [
-      "install",
-      packageName,
-      "-Version",
-      packageVersion,
-      "-DependencyVersion",
-      "ignore",
-      "-OutputDirectory",
-      outputDirectory
-    ]);
-    const initialInstallDirectory = (0, node_path_1.resolve)(outputDirectory, packageName + "." + packageVersion);
-    core.debug(`Renaming ${initialInstallDirectory} to ${installDir}`);
-    yield fs.rename(initialInstallDirectory, installDir);
+    const absolutePath = path.resolve(localPacPath);
+    core.info(`Using preinstalled pac from ${absolutePath}`);
+    yield fs.access(absolutePath, fs.constants.X_OK).catch(() => {
+      throw new Error(`The path ${absolutePath} does not exist or is not executable.`);
+    });
+    if (os.platform() === "win32" && !absolutePath.endsWith("pac.exe")) {
+      throw new Error(`The path ${absolutePath} does point at the expected 'pac.exe'.`);
+    } else if (os.platform() !== "win32" && !absolutePath.endsWith("pac")) {
+      throw new Error(`The path ${absolutePath} does point at the expected 'pac'.`);
+    }
+    core.exportVariable(runnerParameters_1.PacInstalledEnvVarName, "true");
+    core.exportVariable(runnerParameters_1.PacPathEnvVarName, absolutePath);
+    core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match if preinstalled pac is a different version.`);
   });
 }
-function dotnetInstall(packageName, packageVersion, installDir) {
+function nugetInstall(packageName, packageVersion, nugetFeedOverride, nugetFeedUsername, nugetFeedPassword) {
+  return __awaiter(this, void 0, void 0, function* () {
+    core.info(`Installing ${packageName}.${packageVersion} via nuget.exe`);
+    yield checkForInstallationTool("nuget");
+    const toolpath = yield fs.mkdtemp(path.join(os.tmpdir(), "powerplatform-actions-"));
+    let wroteNugetConfig = false;
+    try {
+      if (nugetFeedOverride && nugetFeedOverride !== "https://api.nuget.org/v3/index.json") {
+        core.info(`Adding nuget feed ${nugetFeedOverride} to nuget sources`);
+        yield exec.getExecOutput("nuget", [
+          "sources",
+          "add",
+          "-name",
+          "pacNugetFeed",
+          "-source",
+          nugetFeedOverride,
+          "-username",
+          nugetFeedUsername,
+          "-password",
+          nugetFeedPassword
+        ]);
+        wroteNugetConfig = true;
+      }
+      yield exec.getExecOutput("nuget", [
+        "install",
+        packageName,
+        "-Version",
+        packageVersion,
+        "-DependencyVersion",
+        "ignore",
+        "-NonInteractive",
+        "-OutputDirectory",
+        toolpath
+      ]);
+      const pacPath = (0, node_path_1.resolve)(toolpath, packageName + "." + packageVersion, "tools", "pac.exe");
+      core.exportVariable(runnerParameters_1.PacInstalledEnvVarName, "true");
+      core.exportVariable(runnerParameters_1.PacPathEnvVarName, pacPath);
+    } finally {
+      if (wroteNugetConfig) {
+        yield exec.getExecOutput("nuget", ["sources", "remove", "-name", "pacNugetFeed"]);
+      }
+    }
+  });
+}
+function dotnetInstall(packageName, packageVersion, nugetFeedOverride, nugetFeedUsername, nugetFeedPassword) {
   return __awaiter(this, void 0, void 0, function* () {
     core.info(`Installing ${packageName}.${packageVersion} via dotnet tool install`);
     yield checkForInstallationTool("dotnet");
-    yield exec.getExecOutput("dotnet", [
-      "tool",
-      "install",
-      packageName,
-      "--version",
-      packageVersion,
-      "--tool-path",
-      installDir
-    ]);
+    const toolpath = yield fs.mkdtemp(path.join(os.tmpdir(), "powerplatform-actions-"));
+    let wroteNugetConfig = false;
+    try {
+      if (nugetFeedOverride && nugetFeedOverride !== "https://api.nuget.org/v3/index.json") {
+        core.info(`Adding nuget feed ${nugetFeedOverride} to dotnet nuget sources`);
+        const nugetSourceArgs = ["nuget", "add", "source", nugetFeedOverride, "--name", "pacNugetFeed"];
+        nugetFeedUsername && nugetSourceArgs.push("--username", nugetFeedUsername);
+        nugetFeedPassword && nugetSourceArgs.push("--password", nugetFeedPassword);
+        if (os.platform() !== "win32") {
+          nugetSourceArgs.push("--store-password-in-clear-text");
+        }
+        yield exec.getExecOutput("dotnet", nugetSourceArgs);
+        wroteNugetConfig = true;
+      }
+      yield exec.getExecOutput("dotnet", ["tool", "install", packageName, "--version", packageVersion, "--tool-path", toolpath]);
+      core.exportVariable(runnerParameters_1.PacInstalledEnvVarName, "true");
+      core.exportVariable(runnerParameters_1.PacPathEnvVarName, path.join(toolpath, os.platform() === "win32" ? "pac.exe" : "pac"));
+      core.info(`pac installed to ${process.env[runnerParameters_1.PacPathEnvVarName]}`);
+    } finally {
+      if (wroteNugetConfig) {
+        yield exec.getExecOutput("dotnet", ["nuget", "remove", "source", "pacNugetFeed"]);
+      }
+    }
   });
 }
 function checkForInstallationTool(toolName) {

--- a/dist/actions/add-solution-component/index.js
+++ b/dist/actions/add-solution-component/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/assign-group/index.js
+++ b/dist/actions/assign-group/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/assign-user/index.js
+++ b/dist/actions/assign-user/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/backup-environment/index.js
+++ b/dist/actions/backup-environment/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/branch-solution/index.js
+++ b/dist/actions/branch-solution/index.js
@@ -2345,7 +2345,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -2360,12 +2360,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_12 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -2374,9 +2376,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_12.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/catalog-status/index.js
+++ b/dist/actions/catalog-status/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/check-solution/index.js
+++ b/dist/actions/check-solution/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/clone-solution/index.js
+++ b/dist/actions/clone-solution/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/copy-environment/index.js
+++ b/dist/actions/copy-environment/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/create-environment/index.js
+++ b/dist/actions/create-environment/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/delete-environment/index.js
+++ b/dist/actions/delete-environment/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/delete-solution/index.js
+++ b/dist/actions/delete-solution/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/deploy-package/index.js
+++ b/dist/actions/deploy-package/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/download-paportal/index.js
+++ b/dist/actions/download-paportal/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/export-data/index.js
+++ b/dist/actions/export-data/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/export-solution/index.js
+++ b/dist/actions/export-solution/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/import-data/index.js
+++ b/dist/actions/import-data/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/import-solution/index.js
+++ b/dist/actions/import-solution/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/install-catalog/index.js
+++ b/dist/actions/install-catalog/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/pack-solution/index.js
+++ b/dist/actions/pack-solution/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24190,7 +24192,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24205,12 +24207,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24219,9 +24223,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/publish-solution/index.js
+++ b/dist/actions/publish-solution/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/reset-environment/index.js
+++ b/dist/actions/reset-environment/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/restore-environment/index.js
+++ b/dist/actions/restore-environment/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24238,7 +24240,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24253,12 +24255,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24267,9 +24271,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/set-online-solution-version/index.js
+++ b/dist/actions/set-online-solution-version/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/submit-catalog/index.js
+++ b/dist/actions/submit-catalog/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/unpack-solution/index.js
+++ b/dist/actions/unpack-solution/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24190,7 +24192,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24205,12 +24207,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24219,9 +24223,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/update-solution-version/index.js
+++ b/dist/actions/update-solution-version/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24190,7 +24192,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24205,12 +24207,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24219,9 +24223,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/upgrade-solution/index.js
+++ b/dist/actions/upgrade-solution/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/upload-paportal/index.js
+++ b/dist/actions/upload-paportal/index.js
@@ -2445,8 +2445,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -12397,6 +12397,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -12774,6 +12775,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -24251,7 +24253,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -24266,12 +24268,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -24280,9 +24284,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/dist/actions/who-am-i/index.js
+++ b/dist/actions/who-am-i/index.js
@@ -279,8 +279,8 @@ var require_createPacRunner = __commonJS({
     var os_1 = require("os");
     var path_1 = require("path");
     var CommandRunner_1 = require_CommandRunner();
-    function createPacRunner({ workingDir, runnersDir, logger, agent }) {
-      return (0, CommandRunner_1.createCommandRunner)(workingDir, (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
+    function createPacRunner({ workingDir, runnersDir, pacPath, logger, agent }) {
+      return (0, CommandRunner_1.createCommandRunner)(workingDir, pacPath !== null && pacPath !== void 0 ? pacPath : (0, os_1.platform)() === "win32" ? (0, path_1.resolve)(runnersDir, "pac", "tools", "pac.exe") : (0, path_1.resolve)(runnersDir, "pac_linux", "tools", "pac"), logger, agent, void 0);
     }
     exports2.default = createPacRunner;
   }
@@ -10231,6 +10231,7 @@ var require_restoreEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--name", parameters.targetEnvironmentName);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           validator.pushCommon(pacArgs, parameters);
           if (((_a = validator.getInput(parameters.restoreLatestBackup)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             pacArgs.push("--selected-backup", "latest");
@@ -10608,6 +10609,7 @@ var require_copyEnvironment = __commonJS({
           validator.pushInput(pacArgs, "--source-id", parameters.sourceEnvironmentId);
           validator.pushInput(pacArgs, "--target-id", parameters.targetEnvironmentId);
           validator.pushInput(pacArgs, "--skip-audit-data", parameters.skipAuditData);
+          validator.pushInput(pacArgs, "--max-async-wait-time", parameters.maxAsyncWaitTime);
           if (((_a = validator.getInput(parameters.overrideFriendlyName)) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === "true") {
             validator.pushInput(pacArgs, "--name", parameters.friendlyTargetEnvironmentName);
           }
@@ -14249,7 +14251,7 @@ var require_package = __commonJS({
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -14264,12 +14266,14 @@ var require_runnerParameters = __commonJS({
   "out/lib/runnerParameters.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
-    var process_1 = require("process");
+    exports2.PacPathEnvVarName = exports2.PacInstalledEnvVarName = exports2.getAutomationAgent = exports2.runnerParameters = void 0;
+    var node_process_1 = require("node:process");
     var actionLogger_1 = require_actionLogger();
     var getExePath_1 = require_getExePath();
     var PacInstalledEnvVarName = "POWERPLATFORMTOOLS_PACINSTALLED";
     exports2.PacInstalledEnvVarName = PacInstalledEnvVarName;
+    var PacPathEnvVarName = "POWERPLATFORMTOOLS_PACPATH";
+    exports2.PacPathEnvVarName = PacPathEnvVarName;
     function getAutomationAgent() {
       const jsonPackage = require_package();
       const productName = jsonPackage.name.split("/")[1];
@@ -14278,9 +14282,10 @@ var require_runnerParameters = __commonJS({
     exports2.getAutomationAgent = getAutomationAgent;
     var ActionsRunnerParameters = class {
       constructor() {
-        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, process_1.cwd)();
+        this.workingDir = process.env["GITHUB_WORKSPACE"] || (0, node_process_1.cwd)();
         this.logger = new actionLogger_1.ActionLogger();
         this.agent = getAutomationAgent();
+        this.pacPath = process.env[PacPathEnvVarName];
       }
       get runnersDir() {
         if (process.env[PacInstalledEnvVarName] !== "true") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.3",
-        "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+        "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
         "date-fns": "^2.30.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1",
@@ -833,16 +833,16 @@
       }
     },
     "node_modules/@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.113",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.113/bdacd2401bc69129d1ba4ec33b76795a90c123bd",
-      "integrity": "sha512-bxEDFJpIoEH8qRJj/psIfnBZvli0MOxL+mDV2qYGQ/dkTmXnPQkpobyZpsKLcMnAEc16A3UVUOBW5AlnU9lOCQ==",
+      "version": "0.1.116",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.116/663e3d3f08f7cb084121bde94440aed9c11b2e2e",
+      "integrity": "sha512-9LI+meWFk12FnpZbRsd+9/4FU+ViAp+DM8G6aEpbJrb4X9zfG4JlTcBKOEsw1MK01s8PZ6rOaHnSw3AEsQdKSA==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "glob": "^10.3.3"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11100,9 +11100,9 @@
       }
     },
     "@microsoft/powerplatform-cli-wrapper": {
-      "version": "0.1.113",
-      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.113/bdacd2401bc69129d1ba4ec33b76795a90c123bd",
-      "integrity": "sha512-bxEDFJpIoEH8qRJj/psIfnBZvli0MOxL+mDV2qYGQ/dkTmXnPQkpobyZpsKLcMnAEc16A3UVUOBW5AlnU9lOCQ==",
+      "version": "0.1.116",
+      "resolved": "https://npm.pkg.github.com/download/@microsoft/powerplatform-cli-wrapper/0.1.116/663e3d3f08f7cb084121bde94440aed9c11b2e2e",
+      "integrity": "sha512-9LI+meWFk12FnpZbRsd+9/4FU+ViAp+DM8G6aEpbJrb4X9zfG4JlTcBKOEsw1MK01s8PZ6rOaHnSw3AEsQdKSA==",
       "requires": {
         "fs-extra": "^11.1.1",
         "glob": "^10.3.3"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.3",
-    "@microsoft/powerplatform-cli-wrapper": "^0.1.113",
+    "@microsoft/powerplatform-cli-wrapper": "^0.1.116",
     "date-fns": "^2.30.0",
     "fs-extra": "^11.1.1",
     "js-yaml": "^4.1",

--- a/src/actions/actions-install/index.ts
+++ b/src/actions/actions-install/index.ts
@@ -4,12 +4,26 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as io from '@actions/io'
 import * as os from "node:os";
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import * as fs from 'node:fs/promises';
-import getExePath from '../../lib/getExePath';
+import * as path from 'node:path'
 import { ActionLogger } from '../../lib/actionLogger';
 import * as PacInfo from "../../pacPackageInfo.json";
-import { PacInstalledEnvVarName } from '../../lib/runnerParameters';
+import { PacInstalledEnvVarName, PacPathEnvVarName } from '../../lib/runnerParameters';
+
+const argName = {
+    versionOverride: 'pac-version-override',
+    nugetFeedOverride: 'nuget-feed-override',
+    nugetFeedUsername: 'nuget-feed-username',
+    nugetFeedPassword: 'nuget-feed-password',
+    localPacPath: 'use-preinstalled-pac'
+};
+
+class MutuallyExclusiveArgsError extends Error {
+    constructor(argument1: string, argument2: string) {
+        super(`Cannot specify both ${argument1} and ${argument2}.`);
+    }
+}
 
 (async () => {
     if (process.env.GITHUB_ACTIONS) {
@@ -23,15 +37,32 @@ import { PacInstalledEnvVarName } from '../../lib/runnerParameters';
 
 export async function main(): Promise<void> {
     core.startGroup('actions-install:');
-    const versionArg = core.getInput('pac-version-override', { required: false, trimWhitespace: true });
 
-    if (versionArg && versionArg !== PacInfo.PacPackageVersion) {
-        core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match with requested version ${versionArg}.`);
+    const args = {
+        versionOverride: core.getInput(argName.versionOverride, { required: false }),
+        nugetFeedOverride: core.getInput(argName.nugetFeedOverride, { required: false }),
+        nugetFeedUsername: core.getInput(argName.nugetFeedUsername, { required: false }),
+        nugetFeedPassword: core.getInput(argName.nugetFeedPassword, { required: false }),
+        localPacPath: core.getInput(argName.localPacPath, { required: false })
+    };
+
+    // Let the Actions runner know to mask secrets if they appear in logs or console output
+    args.nugetFeedPassword && core.setSecret(args.nugetFeedPassword);
+
+    // Argument Validation, as many of these are mutually exclusive
+    if (args.localPacPath && args.nugetFeedOverride) throw new MutuallyExclusiveArgsError(argName.localPacPath, argName.nugetFeedOverride);
+    if (args.localPacPath && args.versionOverride) throw new MutuallyExclusiveArgsError(argName.localPacPath, argName.versionOverride);
+
+    if (args.nugetFeedPassword && !args.nugetFeedOverride) {
+        throw new Error(`Do not provide Authentication args (${argName.nugetFeedPassword}) without providing a feed which requires authentication via ${argName.nugetFeedOverride}.`);
+    }
+    if ((args.nugetFeedPassword && !args.nugetFeedUsername) || (!args.nugetFeedPassword && args.nugetFeedUsername)) {
+        throw new Error(`Cannot specify ${argName.nugetFeedPassword} or ${argName.nugetFeedUsername} without the other.`);
     }
 
-    const packageVersion = versionArg || PacInfo.PacPackageVersion;
-
-    core.info(`Installing pac ${packageVersion}...`);
+    if (args.versionOverride && args.versionOverride !== PacInfo.PacPackageVersion) {
+        core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match with requested version ${args.versionOverride}.`);
+    }
 
     if (process.env[PacInstalledEnvVarName] === 'true') {
         core.warning('PAC is already installed. Skipping installation.');
@@ -39,48 +70,111 @@ export async function main(): Promise<void> {
         return;
     }
 
-    const runnersDir = getExePath();
+    const packageVersion = args.versionOverride || PacInfo.PacPackageVersion;
 
-    if (os.platform() === 'win32') {
-        const installDir = resolve(runnersDir, 'pac');
-        await nugetInstall(PacInfo.PacPackageName, packageVersion, installDir);
+    if (args.localPacPath) {
+        await usingPreinstalledPac(args.localPacPath);
+    } else if (os.platform() === 'win32') {
+        await nugetInstall(PacInfo.PacPackageName, packageVersion, args.nugetFeedOverride, args.nugetFeedUsername, args.nugetFeedPassword);
     } else {
-        const installDir = resolve(runnersDir, 'pac_linux', 'tools');
-        await dotnetInstall(PacInfo.DotnetToolName, packageVersion, installDir);
+        await dotnetInstall(PacInfo.DotnetToolName, packageVersion, args.nugetFeedOverride, args.nugetFeedUsername, args.nugetFeedPassword);
     }
 
-    core.exportVariable(PacInstalledEnvVarName, 'true');
     core.endGroup();
 }
 
-async function nugetInstall(packageName: string, packageVersion: string, installDir: string): Promise<void> {
-    core.info(`Installing ${packageName}.${packageVersion} via nuget.exe`);
-    core.debug(`Installing to ${installDir}`);
+async function usingPreinstalledPac(localPacPath: string): Promise<void> {
+    const absolutePath = path.resolve(localPacPath);
+    core.info(`Using preinstalled pac from ${absolutePath}`)
 
-    const outputDirectory = dirname(installDir);
+    // Check that the path exists and is executable
+    await fs.access(absolutePath, fs.constants.X_OK).catch(() => {
+        throw new Error(`The path ${absolutePath} does not exist or is not executable.`);
+    });
+
+    if (os.platform() === 'win32' && !absolutePath.endsWith('pac.exe')) {
+        throw new Error(`The path ${absolutePath} does point at the expected 'pac.exe'.`);
+    } else if (os.platform() !== 'win32' && !absolutePath.endsWith('pac')) {
+        throw new Error(`The path ${absolutePath} does point at the expected 'pac'.`);
+    }
+
+    core.exportVariable(PacInstalledEnvVarName, 'true');
+    core.exportVariable(PacPathEnvVarName, absolutePath);
+    core.warning(`Actions built targetting PAC ${PacInfo.PacPackageVersion}, so Action and PAC parameters might not match if preinstalled pac is a different version.`);
+}
+
+async function nugetInstall(packageName: string, packageVersion: string, nugetFeedOverride: string, nugetFeedUsername: string, nugetFeedPassword: string): Promise<void> {
+    core.info(`Installing ${packageName}.${packageVersion} via nuget.exe`);
 
     await checkForInstallationTool('nuget');
 
-    await exec.getExecOutput('nuget', ['install', packageName,
-        '-Version', packageVersion,
-        '-DependencyVersion', 'ignore', // There are no dependencies, so don't waste that time checking
-        '-OutputDirectory', outputDirectory]);
+    const toolpath = await fs.mkdtemp(path.join(os.tmpdir(), 'powerplatform-actions-'));
+    let wroteNugetConfig = false;
 
-    // Nuget.exe installs to [PackageName].[PackageVersion], but we need this to be 'pac' to match
-    // the cli-wrapper logic.
-    const initialInstallDirectory = resolve(outputDirectory, packageName + '.' + packageVersion);
-    core.debug(`Renaming ${initialInstallDirectory} to ${installDir}`);
-    await fs.rename(initialInstallDirectory, installDir);
+    try {
+        if (nugetFeedOverride && nugetFeedOverride !== 'https://api.nuget.org/v3/index.json') {
+            core.info(`Adding nuget feed ${nugetFeedOverride} to nuget sources`);
+
+            await exec.getExecOutput('nuget', ['sources', 'add', '-name', 'pacNugetFeed', '-source', nugetFeedOverride,
+                '-username', nugetFeedUsername, '-password', nugetFeedPassword]);
+
+            wroteNugetConfig = true;
+        }
+
+        await exec.getExecOutput('nuget', ['install', packageName,
+            '-Version', packageVersion,
+            '-DependencyVersion', 'ignore', // There are no dependencies, so don't waste that time checking
+            '-NonInteractive',
+            '-OutputDirectory', toolpath]);
+
+        const pacPath = resolve(toolpath, packageName + '.' + packageVersion, 'tools', 'pac.exe');
+        core.exportVariable(PacInstalledEnvVarName, 'true');
+        core.exportVariable(PacPathEnvVarName, pacPath);
+    } finally {
+        if (wroteNugetConfig) {
+            // Clean up the nuget config we wrote
+            await exec.getExecOutput('nuget', ['sources', 'remove', '-name', 'pacNugetFeed']);
+        }
+    }
 }
 
-async function dotnetInstall(packageName: string, packageVersion: string, installDir: string): Promise<void> {
+async function dotnetInstall(packageName: string, packageVersion: string, nugetFeedOverride: string, nugetFeedUsername: string, nugetFeedPassword: string): Promise<void> {
     core.info(`Installing ${packageName}.${packageVersion} via dotnet tool install`);
 
     await checkForInstallationTool('dotnet');
 
-    await exec.getExecOutput('dotnet', ['tool', 'install', packageName,
-        '--version', packageVersion,
-        '--tool-path', installDir]);
+    const toolpath = await fs.mkdtemp(path.join(os.tmpdir(), 'powerplatform-actions-'));
+    let wroteNugetConfig = false;
+
+    try {
+        if (nugetFeedOverride && nugetFeedOverride !== 'https://api.nuget.org/v3/index.json') {
+            core.info(`Adding nuget feed ${nugetFeedOverride} to dotnet nuget sources`);
+
+            const nugetSourceArgs = ['nuget', 'add', 'source', nugetFeedOverride, '--name', 'pacNugetFeed' ];
+            nugetFeedUsername && nugetSourceArgs.push('--username', nugetFeedUsername);
+            nugetFeedPassword && nugetSourceArgs.push('--password', nugetFeedPassword);
+            if (os.platform() !== 'win32') {
+                // Encrypted credentials are not supported on Linux or macOS
+                nugetSourceArgs.push('--store-password-in-clear-text');
+            }
+
+            await exec.getExecOutput('dotnet', nugetSourceArgs);
+
+            wroteNugetConfig = true;
+        }
+
+        await exec.getExecOutput('dotnet',
+            ['tool', 'install', packageName, '--version', packageVersion, '--tool-path', toolpath]);
+
+        core.exportVariable(PacInstalledEnvVarName, 'true');
+        core.exportVariable(PacPathEnvVarName, path.join(toolpath, os.platform() === 'win32' ? 'pac.exe' : 'pac'));
+        core.info(`pac installed to ${process.env[PacPathEnvVarName]}`);
+    } finally {
+        if (wroteNugetConfig) {
+            // Clean up the nuget config we wrote, as Linux and macOS don't support encrypted credentials,
+            await exec.getExecOutput('dotnet', ['nuget', 'remove', 'source', 'pacNugetFeed']);
+        }
+    }
 }
 
 async function checkForInstallationTool(toolName: string): Promise<void> {

--- a/src/lib/runnerParameters.ts
+++ b/src/lib/runnerParameters.ts
@@ -1,9 +1,10 @@
 import { Logger, RunnerParameters } from "@microsoft/powerplatform-cli-wrapper";
-import { cwd } from "process";
+import { cwd } from "node:process";
 import { ActionLogger } from "./actionLogger";
 import getExePath from "./getExePath";
 
 const PacInstalledEnvVarName = 'POWERPLATFORMTOOLS_PACINSTALLED';
+const PacPathEnvVarName = 'POWERPLATFORMTOOLS_PACPATH';
 
 function getAutomationAgent(): string {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -16,6 +17,7 @@ class ActionsRunnerParameters implements RunnerParameters {
     workingDir: string = process.env['GITHUB_WORKSPACE'] || cwd();
     logger: Logger = new ActionLogger();
     agent: string = getAutomationAgent();
+    pacPath?: string = process.env[PacPathEnvVarName];
 
     public get runnersDir(): string {
         if (process.env[PacInstalledEnvVarName] !== 'true') {
@@ -28,4 +30,4 @@ class ActionsRunnerParameters implements RunnerParameters {
 
 const runnerParameters: RunnerParameters = new ActionsRunnerParameters();
 
-export { runnerParameters, getAutomationAgent, PacInstalledEnvVarName };
+export { runnerParameters, getAutomationAgent, PacInstalledEnvVarName, PacPathEnvVarName };


### PR DESCRIPTION
[AB#3582314](https://dev.azure.com/dynamicscrm/1fb98997-2f9e-4734-be8a-9728680447c2/_workitems/edit/3582314)

## Current State
Today without any changes, users can us the v1 version of the package to install PAC from nuget packages stored in their own private feeds.  Local folders also count as valid feed sources, so users could get copies of the [Microsoft.PowerApps.CL](https://www.nuget.org/packages/Microsoft.PowerApps.CLI) (net48, Windows only) or [Microsoft.PowerApps.CLI.Tool](https://www.nuget.org/packages/Microsoft.PowerApps.CLI.Tool) (net6.0, cross-plat but only used for Linux/macOS currently) packages through their companies approval process, and added either to internal feeds or as artifacts directly downloaded onto their build agent / actiosn runner.

Examples:
```yaml
jobs:
  Config-before-our-actions-authenticated-feed:
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        os: [windows-latest, ubuntu-latest]
      fail-fast: false 
    steps:
      - run: dotnet nuget add source https://pkgs.dev.azure.com/REDACTED/nuget/v3/index.json -n InternalFeed -u foo -p ${{ secrets.AZ_DevOps_Read_PAT }} --store-password-in-clear-text
      - name: Install PAC
        uses: microsoft/powerplatform-actions/actions-install@v1
        with:
          pac-version-override: 1.27.1-daily-23082819
      - name: Who Am I test
        uses: microsoft/powerplatform-actions/who-am-i@v1
        with:
          environment-url: ${{ env.WF_ENVIRONMENT_URL }}
          user-name: ${{ env.WF_USERNAME }}
          password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}

  Config-before-our-actions-local-folder:
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        os: [windows-latest, ubuntu-latest]
      fail-fast: false 
    steps:
      - uses: actions/checkout@v4
      - run: dotnet nuget add source ${{ github.workspace }}/localNuget
      - name: Install PAC
        uses: microsoft/powerplatform-actions/actions-install@v1
        with:
          pac-version-override: 1.26.6
      - name: Who Am I test
        uses: microsoft/powerplatform-actions/who-am-i@v1
        with:
          environment-url: ${{ env.WF_ENVIRONMENT_URL }}
          user-name: ${{ env.WF_USERNAME }}
          password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
```
![image](https://github.com/microsoft/powerplatform-actions/assets/3751389/65638d38-f93f-491c-ab19-35690ad2a57a)

--------------------------------

## This Change

### Using a different feed, including private feed authentication options

These changes add some install options to the `actions-install` step to allow overriding the nuget feed, without needing to do so in a previous step, and creates the nuget config file without nuget.org present when overridden so that no communication outside is attempted.

```yaml
New-Feed-Params-authenticated-feed:
  runs-on: ${{ matrix.os }}
  strategy:
    matrix:
      os: [windows-latest, ubuntu-latest]
    fail-fast: false
  steps:
    - name: Install PAC
      uses: microsoft/powerplatform-actions/actions-install@tehcrash-install-improvements
      with:
        pac-version-override: 1.27.1-daily-23082819
        nuget-feed-override: https://pkgs.dev.azure.com/REDACTED/nuget/v3/index.json
        nuget-feed-username: foo  # ADO feeds like this one require a non-empty value for the username, but don't use it 
        nuget-feed-password: ${{ secrets.AZ_DevOps_Read_PAT }} 
    - name: Who Am I test
      uses: microsoft/powerplatform-actions/who-am-i@tehcrash-install-improvements
      with:
        environment-url: ${{ env.WF_ENVIRONMENT_URL }}
        user-name: ${{ env.WF_USERNAME }}
        password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
```

### Using a local folder where the PAC nuget package has already been downloaded to

and like before, a local folder containing already-downloaded nuget packages is likewise valid:
```yaml
New-Feed-Params-local-package-folder:
  runs-on: ${{ matrix.os }}
  strategy:
    matrix:
      os: [windows-latest, ubuntu-latest]
    fail-fast: false
  steps:
    - uses: actions/checkout@v4
    - name: Install PAC
      uses: microsoft/powerplatform-actions/actions-install@tehcrash-install-improvements
      with:
        pac-version-override: 1.26.6
        nuget-feed-override: ${{ github.workspace }}/localNuget  # The feed here is a local folder where the .nupkg already exists
    - name: Who Am I test
      uses: microsoft/powerplatform-actions/who-am-i@tehcrash-install-improvements
      with:
        environment-url: ${{ env.WF_ENVIRONMENT_URL }}
        user-name: ${{ env.WF_USERNAME }}
        password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
```
![image](https://github.com/microsoft/powerplatform-actions/assets/3751389/49bbede8-6247-49c8-9186-d0ab26fb9c9d)

### Using an already-installed PAC on the actions runner:

`actions-install`'s `use-preinstalled-pac` parameter allows pointing to an existing copy of pac.exe (windows) or pac (linux/mac) 
```yaml
Use-Preinstalled-Pac:
  runs-on: ubuntu-latest
  steps:
    - name: pre-install PAC before running our powerplatform-actions
      run: dotnet tool install Microsoft.PowerApps.CLI.Tool --version 1.26.6 --tool-path ./
    - name: Tell powerplatform-actions where preinstalled PAC is via actions-install step
      uses: microsoft/powerplatform-actions/actions-install@tehcrash-install-improvements
      with: 
        use-preinstalled-pac: ./pac  # Path to the already-installed PAC executable
    - name: Who Am I test
      uses: microsoft/powerplatform-actions/who-am-i@tehcrash-install-improvements
      with:
        environment-url: ${{ env.WF_ENVIRONMENT_URL }}
        user-name: ${{ env.WF_USERNAME }}
        password-secret: ${{ secrets.PASSWORD_PPDEVTOOLS }}
```
![image](https://github.com/microsoft/powerplatform-actions/assets/3751389/7eaa1fb9-2b89-4066-afea-14646ecaeee3)
