### PR TITLE
bump PAC CLI to 2.7.4

### DIFF
--- a/src/pacPackageInfo.json
+++ b/src/pacPackageInfo.json
@@ -2,5 +2,5 @@
     "PacPackageName": "Microsoft.PowerApps.CLI",
     "LegacyLinuxPackage": "Microsoft.PowerApps.CLI.Core.linux-x64",
     "DotnetToolName": "Microsoft.PowerApps.CLI.Tool",
-    "PacPackageVersion": "1.43.6"
+    "PacPackageVersion": "2.7.4"
 }


### PR DESCRIPTION
## Summary
- Update [src/pacPackageInfo.json](src/pacPackageInfo.json) from PAC CLI `1.43.6` to `2.7.4` (latest stable on NuGet).

## Test plan
- [ ] CI build succeeds with the new package version.
- [ ] Verify `actions-install` resolves and installs `Microsoft.PowerApps.CLI` `2.7.4` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)