### PR TITLE
bump PAC CLI from 2.7.4 to 2.8.1

### DIFF
--- a/dist/actions/actions-install/index.js
+++ b/dist/actions/actions-install/index.js
@@ -19808,7 +19808,7 @@ var require_pacPackageInfo = __commonJS({
       PacPackageName: "Microsoft.PowerApps.CLI",
       LegacyLinuxPackage: "Microsoft.PowerApps.CLI.Core.linux-x64",
       DotnetToolName: "Microsoft.PowerApps.CLI.Tool",
-      PacPackageVersion: "2.7.4"
+      PacPackageVersion: "2.8.1"
     };
   }
 });

--- a/src/pacPackageInfo.json
+++ b/src/pacPackageInfo.json
@@ -2,5 +2,5 @@
     "PacPackageName": "Microsoft.PowerApps.CLI",
     "LegacyLinuxPackage": "Microsoft.PowerApps.CLI.Core.linux-x64",
     "DotnetToolName": "Microsoft.PowerApps.CLI.Tool",
-    "PacPackageVersion": "2.7.4"
+    "PacPackageVersion": "2.8.1"
 }


### PR DESCRIPTION
## Summary
- Updates `src/pacPackageInfo.json` PAC version from 2.7.4 to 2.8.1
- Rebundles affected action dist files against the new PAC release

Only `dist/actions/actions-install/index.js` changes in addition to `pacPackageInfo.json` — that's the only action that embeds the PAC package version directly. The other 30 actions resolve PAC at runtime via env vars set by `actions-install` (`POWERPLATFORMTOOLS_PACINSTALLED` / `POWERPLATFORMTOOLS_PACPATH`), so their bundles rebuild byte-identically.

PAC 2.8.1 verified available on nuget.org.

## Test plan
- [ ] Existing CI matrix runs against the new PAC binary on both ubuntu-latest and windows-latest
- [ ] Smoke-test one action (e.g. `who-am-i` or `export-solution`) end-to-end with PAC 2.8.1