### PR TITLE
Fix CVE-2026-33750: bump brace-expansion 2.0.2 -> 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2532,15 +2532,12 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "uuid": "^9.0.1"
   },
   "overrides": {
-    "brace-expansion": "2.0.2",
+    "brace-expansion": "2.0.3",
     "nanoid": "3.3.11"
   }
 }


### PR DESCRIPTION
## What
Bumps the pinned `brace-expansion` override from **2.0.2** to **2.0.3**.

## Why
Resolves the S360 **[SFI-ES5.2] 1ES Open Source Vulnerabilities** action item for Power Apps App Deployment (`brace-expansion` ReDoS, **CVE-2026-33750**). Matches the remediation already present in `powerplatform-build-tools`.

## Validation
- `npm install` -> lockfile resolves `brace-expansion@2.0.3`
- `npm run build` passes
- `npm test` passes (36 passing)

Only `package.json` and `package-lock.json` are changed.